### PR TITLE
add vwap to agg DTO

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -19,4 +19,8 @@ trigger:
   event:
   - pull_request
 
+---
+kind: signature
+hmac: 5d76d7f02aa880999adb725d231e2ed0556bb618f256753d3bc14a294e8f9646
+
 ...

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.github.polygon-io:client-jvm:1.1.1' 
+    implementation 'com.github.polygon-io:client-jvm:1.2.2' 
 }
 ```
 

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/Aggregates.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/Aggregates.kt
@@ -72,6 +72,7 @@ data class AggregatesDTO(
 data class AggregateDTO(
     @SerialName("T") val ticker: String? = null,
     @SerialName("v") val volume: Double? = null,
+    @SerialName("vw") val volumeWeightedAveragePrice: Double? = null,
     @SerialName("o") val open: Double? = null,
     @SerialName("c") val close: Double? = null,
     @SerialName("l") val low: Double? = null,


### PR DESCRIPTION
`AggregateDTO` was missing the VWAP field.

This addresses issue #17 

Also in this PR: add drone signature hash to protect repo, update version in README