### PR TITLE
Ktor upgrade to 2.1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,7 @@
 *.iml
 .gradle
 /local.properties
-/.idea/caches
-/.idea/libraries
-/.idea/modules.xml
-/.idea/workspace.xml
-/.idea/navEditor.xml
-/.idea/assetWizardSettings.xml
+/.idea/
 .DS_Store
 /build
 /captures

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ group = "com.github.mmoghaddam385"
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.10")
 
-    val ktorVersion = "2.1.2"
+    val ktorVersion = "2.1.3"
     implementation("io.ktor:ktor-client-core-jvm:$ktorVersion")
     implementation("io.ktor:ktor-client-websockets-jvm:$ktorVersion")
     implementation("io.ktor:ktor-client-okhttp-jvm:$ktorVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,8 @@ dependencies {
     implementation("io.ktor:ktor-client-core-jvm:$ktorVersion")
     implementation("io.ktor:ktor-client-websockets-jvm:$ktorVersion")
     implementation("io.ktor:ktor-client-okhttp-jvm:$ktorVersion")
-    implementation("io.ktor:ktor-client-serialization-jvm:$ktorVersion")
+    implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
+    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
 
     // Annotation processor that generates Java builders for data classes
     val ktBuilderVersion = "1.2.1"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,10 +23,10 @@ group = "com.github.mmoghaddam385"
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.10")
 
-    val ktorVersion = "1.6.7"
-    implementation("io.ktor:ktor-client-core:$ktorVersion")
-    implementation("io.ktor:ktor-client-websockets:$ktorVersion")
-    implementation("io.ktor:ktor-client-okhttp:$ktorVersion")
+    val ktorVersion = "2.1.2"
+    implementation("io.ktor:ktor-client-core-jvm:$ktorVersion")
+    implementation("io.ktor:ktor-client-websockets-jvm:$ktorVersion")
+    implementation("io.ktor:ktor-client-okhttp-jvm:$ktorVersion")
     implementation("io.ktor:ktor-client-serialization-jvm:$ktorVersion")
 
     // Annotation processor that generates Java builders for data classes
@@ -34,7 +34,7 @@ dependencies {
     implementation("com.thinkinglogic.builder:kotlin-builder-annotation:$ktBuilderVersion")
     kapt("com.thinkinglogic.builder:kotlin-builder-processor:$ktBuilderVersion")
 
-    testImplementation("junit:junit:4.12")
+    testImplementation("junit:junit:4.13.2")
 }
 
 allprojects {

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
     implementation("com.squareup.okhttp3:okhttp:4.7.2")
 
     // For custom CIO engine on defaultJvmHttpClientProvider
-    implementation("io.ktor:ktor-client-cio:1.3.1")
+    implementation("io.ktor:ktor-client-cio-jvm:2.1.2")
 
     // For pretty printing data classes
     implementation("com.tylerthrailkill.helpers:pretty-print:2.0.2")

--- a/src/main/kotlin/io/polygon/kotlin/sdk/HttpClientProvider.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/HttpClientProvider.kt
@@ -3,10 +3,10 @@ package io.polygon.kotlin.sdk
 import io.ktor.client.*
 import io.ktor.client.engine.*
 import io.ktor.client.engine.okhttp.*
-import io.ktor.client.plugins.json.JsonPlugin
-import io.ktor.client.plugins.kotlinx.serializer.*
+import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.plugins.websocket.*
 import io.ktor.http.*
+import io.ktor.serialization.kotlinx.json.*
 import kotlinx.serialization.json.Json
 import okhttp3.Interceptor
 
@@ -55,8 +55,8 @@ constructor(
     override fun buildClient() =
         HttpClient(buildEngine()) {
             install(WebSockets)
-            install(JsonPlugin) {
-                serializer = KotlinxSerializer(Json {
+            install(ContentNegotiation) {
+                json(Json {
                     isLenient = true
                     ignoreUnknownKeys = true
                 })

--- a/src/main/kotlin/io/polygon/kotlin/sdk/HttpClientProvider.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/HttpClientProvider.kt
@@ -3,9 +3,9 @@ package io.polygon.kotlin.sdk
 import io.ktor.client.*
 import io.ktor.client.engine.*
 import io.ktor.client.engine.okhttp.*
-import io.ktor.client.features.json.JsonFeature
-import io.ktor.client.features.json.serializer.*
-import io.ktor.client.features.websocket.*
+import io.ktor.client.plugins.json.JsonPlugin
+import io.ktor.client.plugins.kotlinx.serializer.*
+import io.ktor.client.plugins.websocket.*
 import io.ktor.http.*
 import kotlinx.serialization.json.Json
 import okhttp3.Interceptor
@@ -55,7 +55,7 @@ constructor(
     override fun buildClient() =
         HttpClient(buildEngine()) {
             install(WebSockets)
-            install(JsonFeature) {
+            install(JsonPlugin) {
                 serializer = KotlinxSerializer(Json {
                     isLenient = true
                     ignoreUnknownKeys = true

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/Aggregates.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/Aggregates.kt
@@ -2,6 +2,7 @@ package io.polygon.kotlin.sdk.rest
 
 import com.thinkinglogic.builder.annotation.Builder
 import com.thinkinglogic.builder.annotation.DefaultValue
+import io.ktor.http.*
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/GroupedDaily.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/GroupedDaily.kt
@@ -2,6 +2,7 @@ package io.polygon.kotlin.sdk.rest
 
 import com.thinkinglogic.builder.annotation.Builder
 import com.thinkinglogic.builder.annotation.DefaultValue
+import io.ktor.http.*
 import io.polygon.kotlin.sdk.rest.reference.PolygonReferenceClient
 
 /** See [PolygonRestClient.getGroupedDailyAggregatesBlocking] */

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/PolygonRestClient.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/PolygonRestClient.kt
@@ -1,6 +1,7 @@
 package io.polygon.kotlin.sdk.rest
 
 import io.ktor.client.HttpClient
+import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.http.URLBuilder
 import io.polygon.kotlin.sdk.DefaultJvmHttpClientProvider
@@ -92,7 +93,7 @@ constructor(
         urlBuilderBlock: URLBuilder.() -> Unit
     ): T {
         val url = baseUrlBuilder.apply(urlBuilderBlock).build()
-        return withHttpClient { httpClient -> httpClient.get(url) }
+        return withHttpClient { httpClient -> httpClient.get(url) }.body()
     }
 
 }

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/crypto/DailyOpenClose.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/crypto/DailyOpenClose.kt
@@ -1,6 +1,7 @@
 package io.polygon.kotlin.sdk.rest.crypto
 
 import com.thinkinglogic.builder.annotation.Builder
+import io.ktor.http.*
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/crypto/Exchanges.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/crypto/Exchanges.kt
@@ -1,5 +1,6 @@
 package io.polygon.kotlin.sdk.rest.crypto
 
+import io.ktor.http.*
 import kotlinx.serialization.Serializable
 
 /** See [PolygonCryptoClient.getSupportedExchangesBlocking] */

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/crypto/HistoricTrades.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/crypto/HistoricTrades.kt
@@ -1,6 +1,7 @@
 package io.polygon.kotlin.sdk.rest.crypto
 
 import com.thinkinglogic.builder.annotation.Builder
+import io.ktor.http.*
 import kotlinx.serialization.Serializable
 
 /** See [PolygonCryptoClient.getHistoricTradesBlocking] */

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/crypto/LastTrade.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/crypto/LastTrade.kt
@@ -1,5 +1,6 @@
 package io.polygon.kotlin.sdk.rest.crypto
 
+import io.ktor.http.*
 import kotlinx.serialization.Serializable
 
 /** See [PolygonCryptoClient.getLastTradeBlocking] */

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/crypto/Snapshots.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/crypto/Snapshots.kt
@@ -1,5 +1,6 @@
 package io.polygon.kotlin.sdk.rest.crypto
 
+import io.ktor.http.*
 import io.polygon.kotlin.sdk.rest.stocks.GainersOrLosersDirection
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/forex/HistoricTicks.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/forex/HistoricTicks.kt
@@ -1,6 +1,7 @@
 package io.polygon.kotlin.sdk.rest.forex
 
 import com.thinkinglogic.builder.annotation.Builder
+import io.ktor.http.*
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/forex/LastQuote.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/forex/LastQuote.kt
@@ -1,5 +1,6 @@
 package io.polygon.kotlin.sdk.rest.forex
 
+import io.ktor.http.*
 import kotlinx.serialization.Serializable
 
 /** See [PolygonForexClient.getLastQuoteBlocking] */

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/forex/RealTimeConversion.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/forex/RealTimeConversion.kt
@@ -2,6 +2,7 @@ package io.polygon.kotlin.sdk.rest.forex
 
 import com.thinkinglogic.builder.annotation.Builder
 import com.thinkinglogic.builder.annotation.DefaultValue
+import io.ktor.http.*
 import kotlinx.serialization.Serializable
 
 /** See [PolygonForexClient.getRealTimeConversionBlocking] */

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/forex/Snapshots.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/forex/Snapshots.kt
@@ -1,5 +1,6 @@
 package io.polygon.kotlin.sdk.rest.forex
 
+import io.ktor.http.*
 import io.polygon.kotlin.sdk.rest.stocks.GainersOrLosersDirection
 import io.polygon.kotlin.sdk.rest.stocks.SnapshotAggregateDTO
 import kotlinx.serialization.SerialName

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/Locales.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/Locales.kt
@@ -1,5 +1,6 @@
 package io.polygon.kotlin.sdk.rest.reference
 
+import io.ktor.http.*
 import kotlinx.serialization.Serializable
 
 /** See [PolygonReferenceClient.getSupportedLocalesBlocking] */

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/MarketHolidays.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/MarketHolidays.kt
@@ -1,5 +1,6 @@
 package io.polygon.kotlin.sdk.rest.reference
 
+import io.ktor.http.*
 import kotlinx.serialization.Serializable
 
 /** See [PolygonReferenceClient.getMarketHolidaysBlocking] */

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/MarketStatus.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/MarketStatus.kt
@@ -1,5 +1,6 @@
 package io.polygon.kotlin.sdk.rest.reference
 
+import io.ktor.http.*
 import kotlinx.serialization.Serializable
 
 /** See [PolygonReferenceClient.getMarketStatusBlocking] */

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/Markets.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/Markets.kt
@@ -1,5 +1,6 @@
 package io.polygon.kotlin.sdk.rest.reference
 
+import io.ktor.http.*
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/StockDividends.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/StockDividends.kt
@@ -1,5 +1,6 @@
 package io.polygon.kotlin.sdk.rest.reference
 
+import io.ktor.http.*
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/StockFinancials.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/StockFinancials.kt
@@ -1,6 +1,7 @@
 package io.polygon.kotlin.sdk.rest.reference
 
 import com.thinkinglogic.builder.annotation.Builder
+import io.ktor.http.*
 import kotlinx.serialization.Serializable
 
 /** See [PolygonReferenceClient.getStockFinancialsBlocking] */

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/StockSplits.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/StockSplits.kt
@@ -1,5 +1,6 @@
 package io.polygon.kotlin.sdk.rest.reference
 
+import io.ktor.http.*
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/TickerDetails.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/TickerDetails.kt
@@ -1,5 +1,6 @@
 package io.polygon.kotlin.sdk.rest.reference
 
+import io.ktor.http.*
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/TickerNews.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/TickerNews.kt
@@ -2,6 +2,7 @@ package io.polygon.kotlin.sdk.rest.reference
 
 import com.thinkinglogic.builder.annotation.Builder
 import com.thinkinglogic.builder.annotation.DefaultValue
+import io.ktor.http.*
 import kotlinx.serialization.Serializable
 
 /** See [PolygonReferenceClient.getTickerNewsBlocking] */

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/TickerTypes.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/TickerTypes.kt
@@ -1,5 +1,6 @@
 package io.polygon.kotlin.sdk.rest.reference
 
+import io.ktor.http.*
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/Tickers.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/Tickers.kt
@@ -2,6 +2,7 @@ package io.polygon.kotlin.sdk.rest.reference
 
 import com.thinkinglogic.builder.annotation.Builder
 import com.thinkinglogic.builder.annotation.DefaultValue
+import io.ktor.http.*
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/ConditionMappings.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/ConditionMappings.kt
@@ -1,5 +1,7 @@
 package io.polygon.kotlin.sdk.rest.stocks
 
+import io.ktor.http.*
+
 /** See [PolygonStocksClient.getConditionMappingsBlocking] */
 suspend fun PolygonStocksClient.getConditionMappings(type: ConditionMappingTickerType): Map<String, String> =
     polygonClient.fetchResult { path("v1", "meta", "conditions", type.urlParamName) }

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/DailyOpenClose.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/DailyOpenClose.kt
@@ -1,5 +1,6 @@
 package io.polygon.kotlin.sdk.rest.stocks
 
+import io.ktor.http.*
 import kotlinx.serialization.Serializable
 
 /** See [PolygonStocksClient.getDailyOpenCloseBlocking] */

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/Exchanges.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/Exchanges.kt
@@ -1,5 +1,6 @@
 package io.polygon.kotlin.sdk.rest.stocks
 
+import io.ktor.http.*
 import kotlinx.serialization.Serializable
 
 /** See [PolygonStocksClient.getSupportedExchangesBlocking] */

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/HistoricQuotes.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/HistoricQuotes.kt
@@ -2,6 +2,7 @@ package io.polygon.kotlin.sdk.rest.stocks
 
 import com.thinkinglogic.builder.annotation.Builder
 import com.thinkinglogic.builder.annotation.DefaultValue
+import io.ktor.http.*
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/HistoricTrades.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/HistoricTrades.kt
@@ -2,6 +2,7 @@ package io.polygon.kotlin.sdk.rest.stocks
 
 import com.thinkinglogic.builder.annotation.Builder
 import com.thinkinglogic.builder.annotation.DefaultValue
+import io.ktor.http.*
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/LastQuote.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/LastQuote.kt
@@ -1,5 +1,6 @@
 package io.polygon.kotlin.sdk.rest.stocks
 
+import io.ktor.http.*
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/LastTrade.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/LastTrade.kt
@@ -1,5 +1,6 @@
 package io.polygon.kotlin.sdk.rest.stocks
 
+import io.ktor.http.*
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/PreviousClose.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/PreviousClose.kt
@@ -1,5 +1,6 @@
 package io.polygon.kotlin.sdk.rest.stocks
 
+import io.ktor.http.*
 import io.polygon.kotlin.sdk.rest.AggregateDTO
 import kotlinx.serialization.Serializable
 

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/Snapshots.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/Snapshots.kt
@@ -1,5 +1,6 @@
 package io.polygon.kotlin.sdk.rest.stocks
 
+import io.ktor.http.*
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/src/main/kotlin/io/polygon/kotlin/sdk/websocket/PolygonWebSocketClient.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/websocket/PolygonWebSocketClient.kt
@@ -1,10 +1,10 @@
 package io.polygon.kotlin.sdk.websocket
 
 import io.ktor.client.*
-import io.ktor.client.features.websocket.*
+import io.ktor.client.plugins.websocket.*
 import io.ktor.client.request.*
 import io.ktor.http.*
-import io.ktor.http.cio.websocket.*
+import io.ktor.websocket.*
 import io.polygon.kotlin.sdk.DefaultJvmHttpClientProvider
 import io.polygon.kotlin.sdk.HttpClientProvider
 import io.polygon.kotlin.sdk.ext.PolygonCompletionCallback


### PR DESCRIPTION
Migrating to ktor 2.1.2 to address security vulnerabilities (like https://devhub.checkmarx.com/cve-details/CVE-2022-29035/) and just for keeping the project up to date.