### PR TITLE
deprecating referance methods poc

### DIFF
--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/PolygonReferenceClient.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/PolygonReferenceClient.kt
@@ -38,12 +38,12 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      * API Doc: https://polygon.io/docs/#!/Reference/get_v2_reference_types
      */
 
-    @Deprecated("use getSupportedTickerTypesBlocking with params arg", ReplaceWith("getSupportedTickerTypesBlocking(params, *opts)"))
+    @Deprecated("use getTickerTypesBlocking", ReplaceWith("getTickerTypesBlocking(params, *opts)"))
     fun getSupportedTickerTypesBlocking(vararg opts: PolygonRestOption): TickerTypesDTO =
         runBlocking { getSupportedTickerTypes(*opts) }
 
     /** See [getSupportedTickerTypesBlocking] */
-    @Deprecated("use getSupportedTickerTypes with params arg", ReplaceWith("getSupportedTickerTypes(params, callback, *opts)"))
+    @Deprecated("use getTickerTypes", ReplaceWith("getTickerTypes(params, callback, *opts)"))
     fun getSupportedTickerTypes(callback: PolygonRestApiCallback<TickerTypesDTO>, vararg opts: PolygonRestOption) {
         coroutineToRestCallback(callback, { getSupportedTickerTypes(*opts) })
     }
@@ -53,12 +53,13 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/stocks/get_v3_reference_tickers_types
      */
-    fun getSupportedTickerTypesBlocking(params: TickerTypeParameters, vararg opts: PolygonRestOption): TickerTypesResponse =
-        runBlocking { getSupportedTickerTypes(params, *opts )}
+    fun getTickerTypesBlocking(params: TickerTypeParameters, vararg opts: PolygonRestOption): TickerTypesResponse =
+        runBlocking { getTickerTypes(params, *opts )}
 
-    fun getSupportedTickerTypes(params: TickerTypeParameters, callback: PolygonRestApiCallback<TickerTypesResponse>, vararg opts: PolygonRestOption) {
-        coroutineToRestCallback(callback, { getSupportedTickerTypes(params, *opts) })
+    fun getTickerTypes(params: TickerTypeParameters, callback: PolygonRestApiCallback<TickerTypesResponse>, vararg opts: PolygonRestOption) {
+        coroutineToRestCallback(callback, { getTickerTypes(params, *opts) })
     }
+
     /**
      * Gets the details of the symbol company/entity.
      * These are important details which offer an overview of the entity.

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/PolygonReferenceClient.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/PolygonReferenceClient.kt
@@ -36,14 +36,28 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/#!/Reference/get_v2_reference_types
      */
+
+    @Deprecated("use getSupportedTickerTypesBlocking with params arg", ReplaceWith("getSupportedTickerTypesBlocking(params, *opts)"))
     fun getSupportedTickerTypesBlocking(vararg opts: PolygonRestOption): TickerTypesDTO =
         runBlocking { getSupportedTickerTypes(*opts) }
 
     /** See [getSupportedTickerTypesBlocking] */
+    @Deprecated("use getSupportedTickerTypes with params arg", ReplaceWith("getSupportedTickerTypes(params, callback, *opts)"))
     fun getSupportedTickerTypes(callback: PolygonRestApiCallback<TickerTypesDTO>, vararg opts: PolygonRestOption) {
         coroutineToRestCallback(callback, { getSupportedTickerTypes(*opts) })
     }
 
+    /**
+     * List all ticker types that Polygon.io has.
+     *
+     * API Doc: https://polygon.io/docs/stocks/get_v3_reference_tickers_types
+     */
+    fun getSupportedTickerTypesBlocking(params: TickerTypeParameters, vararg opts: PolygonRestOption): TickerTypesResponse =
+        runBlocking { getSupportedTickerTypes(params, *opts )}
+
+    fun getSupportedTickerTypes(params: TickerTypeParameters, callback: PolygonRestApiCallback<TickerTypesResponse>, vararg opts: PolygonRestOption) {
+        coroutineToRestCallback(callback, { getSupportedTickerTypes(params, *opts) })
+    }
     /**
      * Gets the details of the symbol company/entity.
      * These are important details which offer an overview of the entity.

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/PolygonReferenceClient.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/PolygonReferenceClient.kt
@@ -32,6 +32,7 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
     }
 
     /**
+     * @deprecated use new getSupportTickerTypes with params arg
      * Gets all of Polygon's currently supported ticker types
      *
      * API Doc: https://polygon.io/docs/#!/Reference/get_v2_reference_types

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/TickerTypes.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/TickerTypes.kt
@@ -8,11 +8,12 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /** See [PolygonReferenceClient.getSupportedTickerTypesBlocking] */
-@Deprecated("use getSupportedTickerTypes with params arg", ReplaceWith("getSupportedTickerTypes(params, *opts)"))
+@Deprecated("use getTickerTypes", ReplaceWith("getTickerTypes(params, *opts)"))
 suspend fun PolygonReferenceClient.getSupportedTickerTypes(vararg opts: PolygonRestOption): TickerTypesDTO =
     polygonClient.fetchResult({ path("v2", "reference", "types") }, *opts)
 
-suspend fun PolygonReferenceClient.getSupportedTickerTypes(params: TickerTypeParameters, vararg opts: PolygonRestOption): TickerTypesResponse =
+/** See [PolygonReferenceClient.getTickerTypesBlocking]*/
+suspend fun PolygonReferenceClient.getTickerTypes(params: TickerTypeParameters, vararg opts: PolygonRestOption): TickerTypesResponse =
     polygonClient.fetchResult({
         path("v3", "reference", "tickers", "types")
 
@@ -20,13 +21,13 @@ suspend fun PolygonReferenceClient.getSupportedTickerTypes(params: TickerTypePar
         params.locale?.let{ parameters["locale"]=it }
     }, *opts)
 
-@Serializable @Deprecated("used in deprecated getSupportTickerType()")
+@Serializable @Deprecated("used in deprecated getSupportedTickerType()")
 data class TickerTypesDTO(
     val status: String? = null,
     val results: TickerTypeResultsDTO? = null
 )
 
-@Serializable @Deprecated("used in deprecated getSupportTickerType()")
+@Serializable @Deprecated("used in deprecated getSupportedTickerType()")
 data class TickerTypeResultsDTO(
     @SerialName("types") val tickerTypes: Map<String, String> = emptyMap(),
     val indexTypes: Map<String, String> = emptyMap()

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/TickerTypes.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/TickerTypes.kt
@@ -1,22 +1,71 @@
 package io.polygon.kotlin.sdk.rest.reference
 
+import com.thinkinglogic.builder.annotation.Builder
+import com.thinkinglogic.builder.annotation.DefaultValue
 import io.ktor.http.*
 import io.polygon.kotlin.sdk.rest.PolygonRestOption
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /** See [PolygonReferenceClient.getSupportedTickerTypesBlocking] */
+@Deprecated("use getSupportedTickerTypes with params arg", ReplaceWith("getSupportedTickerTypes(params, *opts)"))
 suspend fun PolygonReferenceClient.getSupportedTickerTypes(vararg opts: PolygonRestOption): TickerTypesDTO =
     polygonClient.fetchResult({ path("v2", "reference", "types") }, *opts)
 
-@Serializable
+suspend fun PolygonReferenceClient.getSupportedTickerTypes(params: TickerTypeParameters, vararg opts: PolygonRestOption): TickerTypesResponse =
+    polygonClient.fetchResult({
+        path("v3", "reference", "tickers", "types")
+
+        params.assetClass?.let{ parameters["asset_class"]=it }
+        params.locale?.let{ parameters["locale"]=it }
+    }, *opts)
+
+@Serializable @Deprecated("used in deprecated getSupportTickerType()")
 data class TickerTypesDTO(
     val status: String? = null,
     val results: TickerTypeResultsDTO? = null
 )
 
-@Serializable
+@Serializable @Deprecated("used in deprecated getSupportTickerType()")
 data class TickerTypeResultsDTO(
     @SerialName("types") val tickerTypes: Map<String, String> = emptyMap(),
     val indexTypes: Map<String, String> = emptyMap()
+)
+
+
+@Builder
+data class TickerTypeParameters(
+    /**
+     * Filter by asset class.
+     */
+    val assetClass: String? = null,
+
+    /**
+     * Filter by locale.
+     */
+    val locale: String? = null
+
+)
+
+@Serializable
+data class TickerTypesResponse(
+    // The total number of results for this request.
+    val count: Int? = null,
+    // A request ID assigned by the server.
+    val requestID: String? = null,
+    // The status of this request's response.
+    val status: String? = null,
+    val results: List<TickerType> = emptyList<TickerType>()
+)
+
+@Serializable
+data class TickerType(
+    // An identifier for a group of similar financial instruments.
+    val assetClass: String? = null,
+    // A code used by Polygon.io to refer to this ticker type.
+    val code: String? = null,
+    // A short description of this ticker type.
+    val description: String? = null,
+    // An identifier for a geographical location.
+    val locale: String? = null
 )


### PR DESCRIPTION
Two points that came up from this
- How tied are we to using the `DTO` suffix on those types?
- Do we want to overload the old functions or stretch for new function names?