### PR TITLE
V3 Trades Endpoint w/ Iterator

### DIFF
--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/PolygonRestClient.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/PolygonRestClient.kt
@@ -90,6 +90,34 @@ constructor(
     ) =
         coroutineToRestCallback(callback, { getGroupedDailyAggregates(params, *opts) })
 
+    /**
+     *  Get trades for an equity/options/crypto ticker within a range
+     *  Note that options symbols are prepended with "O:" and crypto with "X:"
+     *
+     * API Docs:
+     *     https://polygon.io/docs/stocks/get_v3_trades__stockticker
+     *     https://polygon.io/docs/options/get_v3_trades__optionsticker
+     *     https://polygon.io/docs/crypto/get_v3_trades__cryptoticker
+     */
+
+    fun getTradesBlocking(
+        params: TradesParameters,
+        vararg opts: PolygonRestOption): TradesResponse =
+        runBlocking { getTrades(params, *opts)}
+
+    fun getTrades(params: TradesParameters, callback: PolygonRestApiCallback<TradesResponse>, vararg opts: PolygonRestOption) {
+        coroutineToRestCallback(callback, {getTrades(params, *opts)})
+    }
+
+    @SafeVarargs
+    fun getTradesIterator(
+        params: TradesParameters,
+        vararg opts: PolygonRestOption
+    ): RequestIterator<TradeResult> =
+        RequestIterator(
+            { getTradesBlocking(params, *opts) },
+            requestIteratorFetch<TradesResponse>()
+        )
 
     private val baseUrlBuilder: URLBuilder
         get() = httpClientProvider.getDefaultRestURLBuilder().apply {

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/PolygonRestClient.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/PolygonRestClient.kt
@@ -109,8 +109,11 @@ constructor(
         coroutineToRestCallback(callback, {getTrades(params, *opts)})
     }
 
+    /**
+     * listTrades is an iterator wrapper for getTrades
+     */
     @SafeVarargs
-    fun getTradesIterator(
+    fun listTrades(
         params: TradesParameters,
         vararg opts: PolygonRestOption
     ): RequestIterator<TradeResult> =

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/Trades.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/Trades.kt
@@ -23,8 +23,7 @@ suspend fun PolygonRestClient.getTrades(
         params.timestampGT?.let { parameters["timestamp.gt"] = it.toString() }
         params.timestampGTE?.let { parameters["timestamp.gte"] = it.toString() }
         params.sort?.let{ parameters["sort"] = it }
-
-        params.limit.let { parameters["limit"] = it.toString() }
+        params.limit?.let { parameters["limit"] = it.toString() }
     }, *opts)
 
 @Builder
@@ -62,9 +61,9 @@ data class TradesParameters(
 
     /**
      * Limit the number of results returned, default is 10 and max is 50000.
+     * The API will default this to 10
      */
-    @DefaultValue("10")
-    val limit: Int = 10,
+    val limit: Int? = null,
 
     /**
      * Field used for ordering. See docs for valid fields
@@ -90,7 +89,5 @@ data class TradeResult(
     val participantTimestamp: Long? = null,
     val price: Double? = null,
     val sipTimestamp: Long? = null,
-
-    // TODO what type should this be? Need Double for crypto size, but lib uses Long in other places for equities
     val size: Double? = null,
 )

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/Trades.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/Trades.kt
@@ -1,0 +1,96 @@
+package io.polygon.kotlin.sdk.rest
+
+import com.thinkinglogic.builder.annotation.Builder
+import com.thinkinglogic.builder.annotation.DefaultValue
+import io.ktor.http.*
+import kotlinx.serialization.Required
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+suspend fun PolygonRestClient.getTrades(
+    params: TradesParameters,
+    vararg opts: PolygonRestOption
+): TradesResponse =
+    fetchResult({
+        path(
+            "v3",
+            "trades",
+            params.ticker,
+        )
+        params.timestamp?.let { parameters["timestamp"] = it.toString() }
+        params.timestampLT?.let { parameters["timestamp.lt"] = it.toString() }
+        params.timestampLTE?.let { parameters["timestamp.lte"] = it.toString() }
+        params.timestampGT?.let { parameters["timestamp.gt"] = it.toString() }
+        params.timestampGTE?.let { parameters["timestamp.gte"] = it.toString() }
+        params.sort?.let{ parameters["sort"] = it }
+
+        params.limit.let { parameters["limit"] = it.toString() }
+    }, *opts)
+
+@Builder
+data class TradesParameters(
+    /**
+     * The ticker symbol to get trades for.
+     */
+    val ticker: String,
+
+    /**
+     *  Query by trade using nanosecond Unix epoch time.
+     *  Use timestampLT/LTE/GT/GTE for additional filtering
+     */
+    val timestamp: Long? = null,
+
+    /**
+     * Return results where this field is less than the value.
+     */
+    val timestampLT: Long? = null,
+
+    /**
+     * Return results where this field is less than or equal to the value.
+     */
+    val timestampLTE: Long? = null,
+
+    /**
+     * Return results where this field is greater than the value.
+     */
+    val timestampGT: Long? = null,
+
+    /**
+     * Return results where this field is greater than or equal to the value.
+     */
+    val timestampGTE: Long? = null,
+
+    /**
+     * Limit the number of results returned, default is 10 and max is 50000.
+     */
+    @DefaultValue("10")
+    val limit: Int = 10,
+
+    /**
+     * Field used for ordering. See docs for valid fields
+     */
+    val sort: String? = null
+)
+
+@Serializable
+data class TradesResponse(
+    val status: String? = null,
+    val requestID: String? = null,
+    override val nextUrl: String? = null,
+    override val results: List<TradeResult>? = null
+) : Paginatable<TradeResult>
+
+
+@Serializable
+data class TradeResult(
+    val placeHolder: String? = null,
+    val conditions: List<Int>? = null,
+    val correction: Int? = null,
+    val exchange: Int? = null,
+    val participantTimestamp: Long? = null,
+    val price: Double? = null,
+    val sipTimestamp: Long? = null,
+
+    // TODO what type should this be? Need Double for crypto size, but lib uses Long in other places for equities
+    val size: Double? = null,
+)


### PR DESCRIPTION
Implementing `/v3/trades` so we can begin deprecating `getHistoricTrades`

This is currently PR'd into the `iterator-poc` branch so the diffs aren't ugly, will rebase and switch over to Master when pagination is merged