### PR TITLE
bring new patterns to trades/quotes and @SafeVarargs everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Everything you'd expect from a client SDK plus...
 
 ## REST Request Options
 
+_Added in v4.1.0_
+
 For most use-cases, the default request options will do the trick, 
 but if you need some more flexibility on a per-request basis, 
 you can configure individual REST API requests with `PolygonRestOption`s.

--- a/sample/src/main/java/io/polygon/kotlin/sdk/sample/JavaIteratorSample.java
+++ b/sample/src/main/java/io/polygon/kotlin/sdk/sample/JavaIteratorSample.java
@@ -28,11 +28,10 @@ public class JavaIteratorSample {
     public static void TradesIteratorSample(PolygonRestClient client) {
         System.out.println("Running trade iterator");
         TradesParameters params = new TradesParametersBuilder()
-                .ticker("F")
                 .limit(1)
                 .build();
 
-        client.listTrades(params)
+        client.listTrades("F", params)
                 .asStream() // Convert to a Java stream for ease of use.
                 .limit(2)
                 .forEach((trade -> System.out.println(trade.getPrice())));
@@ -41,11 +40,10 @@ public class JavaIteratorSample {
     public static void QuotesIteratorSample(PolygonRestClient client) {
         System.out.println("Running Quote iterator");
         QuotesParameters params = new QuotesParametersBuilder()
-                .ticker("F")
                 .limit(1)
                 .build();
 
-        client.listQuotes(params)
+        client.listQuotes("F", params)
                 .asStream() // Convert to a Java stream for ease of use.
                 .limit(2)
                 .forEach((Quote -> System.out.println(Quote.getAskPrice())));

--- a/sample/src/main/java/io/polygon/kotlin/sdk/sample/JavaUsageSample.java
+++ b/sample/src/main/java/io/polygon/kotlin/sdk/sample/JavaUsageSample.java
@@ -1,7 +1,7 @@
 package io.polygon.kotlin.sdk.sample;
 
-import io.polygon.kotlin.sdk.ComparisonQueryFilterParameters;
-import io.polygon.kotlin.sdk.ComparisonQueryFilterParametersBuilder;
+import io.polygon.kotlin.sdk.rest.ComparisonQueryFilterParameters;
+import io.polygon.kotlin.sdk.rest.ComparisonQueryFilterParametersBuilder;
 import io.polygon.kotlin.sdk.rest.*;
 import io.polygon.kotlin.sdk.rest.experimental.FinancialsParameters;
 import io.polygon.kotlin.sdk.rest.experimental.FinancialsParametersBuilder;

--- a/sample/src/main/java/io/polygon/kotlin/sdk/sample/KotlinIteratorSample.kt
+++ b/sample/src/main/java/io/polygon/kotlin/sdk/sample/KotlinIteratorSample.kt
@@ -24,24 +24,18 @@ fun iteratorExample(polygonClient: PolygonRestClient) {
 
 fun tradesIteratorExample(polygonClient: PolygonRestClient) {
     println("Running trade iterator:")
-    val params = TradesParameters(
-        ticker = "F",
-        limit = 1
-    )
+    val params = TradesParameters(limit = 1)
 
-    polygonClient.listTrades(params).asSequence()
+    polygonClient.listTrades("F", params).asSequence()
         .take(2)
         .forEachIndexed { index, tradeRes -> println("${index}: ${tradeRes.price}") }
 }
 
 fun quotesIteratorExample(polygonClient: PolygonRestClient) {
     println("Running quote iterator:")
-    val params = QuotesParameters(
-        ticker = "F",
-        limit = 1
-    )
+    val params = QuotesParameters(limit = 1)
 
-    polygonClient.listQuotes(params).asSequence()
+    polygonClient.listQuotes("F", params).asSequence()
         .take(2)
         .forEachIndexed { index, quoteRes -> println("${index}: (${quoteRes.participantTimestamp}) | ${quoteRes.bidPrice} / ${quoteRes.askPrice}") }
 }

--- a/sample/src/main/java/io/polygon/kotlin/sdk/sample/KotlinUsageSample.kt
+++ b/sample/src/main/java/io/polygon/kotlin/sdk/sample/KotlinUsageSample.kt
@@ -2,7 +2,7 @@ package io.polygon.kotlin.sdk.sample
 
 import com.tylerthrailkill.helpers.prettyprint.pp
 import io.ktor.client.plugins.*
-import io.polygon.kotlin.sdk.ComparisonQueryFilterParameters
+import io.polygon.kotlin.sdk.rest.ComparisonQueryFilterParameters
 import io.polygon.kotlin.sdk.DefaultOkHttpClientProvider
 import io.polygon.kotlin.sdk.HttpClientProvider
 import io.polygon.kotlin.sdk.rest.*
@@ -13,7 +13,6 @@ import io.polygon.kotlin.sdk.rest.experimental.FinancialsParameters
 import io.polygon.kotlin.sdk.rest.forex.HistoricTicksParameters
 import io.polygon.kotlin.sdk.rest.forex.RealTimeConversionParameters
 import io.polygon.kotlin.sdk.rest.reference.*
-import io.polygon.kotlin.sdk.rest.stocks.ConditionMappingTickerType
 import io.polygon.kotlin.sdk.rest.stocks.GainersOrLosersDirection
 import io.polygon.kotlin.sdk.rest.stocks.HistoricQuotesParameters
 import io.polygon.kotlin.sdk.rest.stocks.HistoricTradesParameters

--- a/sample/src/main/java/io/polygon/kotlin/sdk/sample/KotlinUsageSample.kt
+++ b/sample/src/main/java/io/polygon/kotlin/sdk/sample/KotlinUsageSample.kt
@@ -368,19 +368,13 @@ fun cryptoL2SnapshotSample(polygonClient: PolygonRestClient) {
 
 fun getTradesSample(polygonClient: PolygonRestClient) {
     println("F Trades:")
-    var params = TradesParameters(
-        ticker = "F",
-        limit = 2
-    )
-    polygonClient.getTradesBlocking(params).pp()
+    val params = TradesParameters(limit = 2)
+    polygonClient.getTradesBlocking("F", params).pp()
 }
 
 fun getQuotesSample(polygonClient: PolygonRestClient) {
     println("F Quotes")
-    var params = QuotesParameters(
-        ticker = "F",
-        limit = 2
-    )
-    polygonClient.getQuotesBlocking(params).pp()
+    val params = QuotesParameters(limit = 2)
+    polygonClient.getQuotesBlocking("F", params).pp()
 
 }

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/Aggregates.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/Aggregates.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /** See [PolygonRestClient.getAggregatesBlocking] */
+@SafeVarargs
 suspend fun PolygonRestClient.getAggregates(
     params: AggregatesParameters,
     vararg opts: PolygonRestOption

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/ComparisonQueryFilterParameters.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/ComparisonQueryFilterParameters.kt
@@ -1,4 +1,4 @@
-package io.polygon.kotlin.sdk
+package io.polygon.kotlin.sdk.rest
 
 import io.ktor.http.*
 

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/GroupedDaily.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/GroupedDaily.kt
@@ -6,6 +6,7 @@ import io.ktor.http.*
 import io.polygon.kotlin.sdk.rest.reference.PolygonReferenceClient
 
 /** See [PolygonRestClient.getGroupedDailyAggregatesBlocking] */
+@SafeVarargs
 suspend fun PolygonRestClient.getGroupedDailyAggregates(
     params: GroupedDailyParameters,
     vararg opts: PolygonRestOption

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/PolygonRestClient.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/PolygonRestClient.kt
@@ -68,10 +68,12 @@ constructor(
      *
      * API Doc: https://polygon.io/docs/stocks/get_v2_aggs_ticker__stocksticker__range__multiplier___timespan___from___to
      */
+    @SafeVarargs
     fun getAggregatesBlocking(params: AggregatesParameters, vararg opts: PolygonRestOption): AggregatesDTO =
         runBlocking { getAggregates(params, *opts) }
 
     /** See [getAggregatesBlocking] */
+    @SafeVarargs
     fun getAggregates(
         params: AggregatesParameters,
         callback: PolygonRestApiCallback<AggregatesDTO>,
@@ -85,6 +87,7 @@ constructor(
      *
      * API Doc: https://polygon.io/docs/stocks/get_v2_aggs_grouped_locale_us_market_stocks__date
      */
+    @SafeVarargs
     fun getGroupedDailyAggregatesBlocking(
         params: GroupedDailyParameters,
         vararg opts: PolygonRestOption
@@ -92,6 +95,7 @@ constructor(
         runBlocking { getGroupedDailyAggregates(params, *opts) }
 
     /** See [getGroupedDailyAggregatesBlocking] */
+    @SafeVarargs
     fun getGroupedDailyAggregates(
         params: GroupedDailyParameters,
         callback: PolygonRestApiCallback<AggregatesDTO>,
@@ -108,14 +112,22 @@ constructor(
      *     https://polygon.io/docs/options/get_v3_trades__optionsticker
      *     https://polygon.io/docs/crypto/get_v3_trades__cryptoticker
      */
-
+    @SafeVarargs
     fun getTradesBlocking(
+        ticker: String,
         params: TradesParameters,
-        vararg opts: PolygonRestOption): TradesResponse =
-        runBlocking { getTrades(params, *opts)}
+        vararg opts: PolygonRestOption
+    ): TradesResponse =
+        runBlocking { getTrades(ticker, params, *opts) }
 
-    fun getTrades(params: TradesParameters, callback: PolygonRestApiCallback<TradesResponse>, vararg opts: PolygonRestOption) {
-        coroutineToRestCallback(callback, {getTrades(params, *opts)})
+    @SafeVarargs
+    fun getTrades(
+        ticker: String,
+        params: TradesParameters,
+        callback: PolygonRestApiCallback<TradesResponse>,
+        vararg opts: PolygonRestOption
+    ) {
+        coroutineToRestCallback(callback, { getTrades(ticker, params, *opts) })
     }
 
     /**
@@ -123,11 +135,12 @@ constructor(
      */
     @SafeVarargs
     fun listTrades(
+        ticker: String,
         params: TradesParameters,
         vararg opts: PolygonRestOption
-    ): RequestIterator<TradeResult> =
+    ): RequestIterator<Trade> =
         RequestIterator(
-            { getTradesBlocking(params, *opts) },
+            { getTradesBlocking(ticker, params, *opts) },
             requestIteratorFetch<TradesResponse>()
         )
 
@@ -141,27 +154,39 @@ constructor(
      *     https://polygon.io/docs/forex/get_v3_quotes__fxticker
      *     https://polygon.io/docs/options/get_v3_quotes__optionsticker
      */
+    @SafeVarargs
     fun getQuotesBlocking(
+        ticker: String,
         params: QuotesParameters,
-        vararg opts: PolygonRestOption): QuotesResponse =
-        runBlocking { getQuotes(params, *opts)}
+        vararg opts: PolygonRestOption
+    ): QuotesResponse =
+        runBlocking { getQuotes(ticker, params, *opts) }
 
-    fun getQuotes(params: QuotesParameters, callback: PolygonRestApiCallback<QuotesResponse>, vararg opts: PolygonRestOption) {
-        coroutineToRestCallback(callback, {getQuotes(params, *opts)})
+    @SafeVarargs
+    fun getQuotes(
+        ticker: String,
+        params: QuotesParameters,
+        callback: PolygonRestApiCallback<QuotesResponse>,
+        vararg opts: PolygonRestOption
+    ) {
+        coroutineToRestCallback(callback, { getQuotes(ticker, params, *opts) })
     }
 
     /**
-     * listQuotes is an iterator wrapper for getQuotes
+     * Get an iterator to iterate through all pages of results for the given parameters.
+     *
+     * See [getQuotesBlocking] if you instead need to get exactly one page of results.
+     * See section "Pagination" in the README for more details on iterators.
      */
     @SafeVarargs
     fun listQuotes(
+        ticker: String,
         params: QuotesParameters,
         vararg opts: PolygonRestOption
-    ): RequestIterator<QuoteResult> =
-        RequestIterator(
-            { getQuotesBlocking(params, *opts) },
-            requestIteratorFetch<QuotesResponse>()
-        )
+    ): RequestIterator<Quote> = RequestIterator(
+        { getQuotesBlocking(ticker, params, *opts) },
+        requestIteratorFetch<QuotesResponse>()
+    )
 
     private val baseUrlBuilder: URLBuilder
         get() = httpClientProvider.getDefaultRestURLBuilder().apply {

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/Quotes.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/Quotes.kt
@@ -2,8 +2,6 @@ package io.polygon.kotlin.sdk.rest
 
 import com.thinkinglogic.builder.annotation.Builder
 import io.ktor.http.*
-import io.polygon.kotlin.sdk.ComparisonQueryFilterParameters
-import io.polygon.kotlin.sdk.applyComparisonQueryFilterParameters
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/TechnicalIndicators.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/TechnicalIndicators.kt
@@ -2,8 +2,6 @@ package io.polygon.kotlin.sdk.rest
 
 import com.thinkinglogic.builder.annotation.Builder
 import io.ktor.http.*
-import io.polygon.kotlin.sdk.ComparisonQueryFilterParameters
-import io.polygon.kotlin.sdk.applyComparisonQueryFilterParameters
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/Trades.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/Trades.kt
@@ -2,8 +2,6 @@ package io.polygon.kotlin.sdk.rest
 
 import com.thinkinglogic.builder.annotation.Builder
 import io.ktor.http.*
-import io.polygon.kotlin.sdk.ComparisonQueryFilterParameters
-import io.polygon.kotlin.sdk.applyComparisonQueryFilterParameters
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/crypto/DailyOpenClose.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/crypto/DailyOpenClose.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /** See [PolygonCryptoClient.getDailyOpenCloseBlocking] */
+@SafeVarargs
 suspend fun PolygonCryptoClient.getDailyOpenClose(
     params: CryptoDailyOpenCloseParameters,
     vararg opts: PolygonRestOption

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/crypto/Exchanges.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/crypto/Exchanges.kt
@@ -5,6 +5,7 @@ import io.polygon.kotlin.sdk.rest.PolygonRestOption
 import kotlinx.serialization.Serializable
 
 /** See [PolygonCryptoClient.getSupportedExchangesBlocking] */
+@SafeVarargs
 suspend fun PolygonCryptoClient.getSupportedExchanges(vararg opts: PolygonRestOption): List<CryptoExchangeDTO> =
     polygonClient.fetchResult({ path("v1", "meta", "crypto-exchanges") }, *opts)
 

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/crypto/HistoricTrades.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/crypto/HistoricTrades.kt
@@ -6,6 +6,7 @@ import io.polygon.kotlin.sdk.rest.PolygonRestOption
 import kotlinx.serialization.Serializable
 
 /** See [PolygonCryptoClient.getHistoricTradesBlocking] */
+@SafeVarargs
 @Deprecated("superseded by getTrades in PolygonRestClient")
 suspend fun PolygonCryptoClient.getHistoricTrades(
     params: HistoricCryptoTradesParameters,

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/crypto/LastTrade.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/crypto/LastTrade.kt
@@ -5,6 +5,7 @@ import io.polygon.kotlin.sdk.rest.PolygonRestOption
 import kotlinx.serialization.Serializable
 
 /** See [PolygonCryptoClient.getLastTradeBlocking] */
+@SafeVarargs
 suspend fun PolygonCryptoClient.getLastTrade(
     from: String,
     to: String,

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/crypto/PolygonCryptoClient.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/crypto/PolygonCryptoClient.kt
@@ -4,11 +4,14 @@ import io.polygon.kotlin.sdk.ext.coroutineToRestCallback
 import io.polygon.kotlin.sdk.rest.PolygonRestApiCallback
 import io.polygon.kotlin.sdk.rest.PolygonRestClient
 import io.polygon.kotlin.sdk.rest.PolygonRestOption
+import io.polygon.kotlin.sdk.rest.reference.PolygonReferenceClient
 import io.polygon.kotlin.sdk.rest.stocks.GainersOrLosersDirection
 import kotlinx.coroutines.runBlocking
 
 /**
- * Client for Polygon.io's "Crypto" RESTful APIs
+ * Client for Polygon.io's crypto pricing data RESTful APIs.
+ * For common pricing APIs shared across asset classes, see [PolygonRestClient].
+ * For reference data, see [PolygonReferenceClient].
  *
  * You should access this client through [PolygonRestClient]
  */
@@ -20,10 +23,12 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/#get_v1_meta_crypto-exchanges_anchor
      */
+    @SafeVarargs
     fun getSupportedExchangesBlocking(vararg opts: PolygonRestOption): List<CryptoExchangeDTO> =
         runBlocking { getSupportedExchanges(*opts) }
 
     /** See [getSupportedExchangesBlocking] */
+    @SafeVarargs
     fun getSupportedExchanges(callback: PolygonRestApiCallback<List<CryptoExchangeDTO>>) =
         coroutineToRestCallback(callback, { getSupportedExchanges() })
 
@@ -32,10 +37,12 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/crypto/get_v1_last_crypto__from___to
      */
+    @SafeVarargs
     fun getLastTradeBlocking(from: String, to: String, vararg opts: PolygonRestOption): CryptoLastTradeDTO =
         runBlocking { getLastTrade(from, to, *opts) }
 
     /** See [getLastTradeBlocking] */
+    @SafeVarargs
     fun getLastTrade(
         from: String, to: String, callback: PolygonRestApiCallback<CryptoLastTradeDTO>,
         vararg opts: PolygonRestOption
@@ -46,11 +53,13 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/crypto/get_v2_aggs_grouped_locale_global_market_crypto__date
      */
+    @SafeVarargs
     fun getDailyOpenCloseBlocking(params: CryptoDailyOpenCloseParameters, vararg opts: PolygonRestOption):
             CryptoDailyOpenCloseDTO =
         runBlocking { getDailyOpenClose(params, *opts) }
 
     /** See [getDailyOpenCloseBlocking] */
+    @SafeVarargs
     fun getDailyOpenClose(
         params: CryptoDailyOpenCloseParameters,
         callback: PolygonRestApiCallback<CryptoDailyOpenCloseDTO>,
@@ -62,6 +71,7 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/crypto/deprecated/get_v1_historic_crypto__from___to___date
      */
+    @SafeVarargs
     @Deprecated("use listTrades or getTradesBlocking in PolygonRestClient", ReplaceWith("listTrades(params, *opts)"))
     fun getHistoricTradesBlocking(
         params: HistoricCryptoTradesParameters,
@@ -70,6 +80,7 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
         runBlocking { getHistoricTrades(params, *opts) }
 
     /** See [getHistoricTradesBlocking] */
+    @SafeVarargs
     @Deprecated("use listTrades or getTrades in PolygonRestClient", ReplaceWith("listTrades(params, *opts)"))
     fun getHistoricTrades(
         params: HistoricCryptoTradesParameters,
@@ -84,10 +95,12 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/crypto/get_v2_snapshot_locale_global_markets_crypto_tickers
      */
+    @SafeVarargs
     fun getSnapshotAllTickersBlocking(vararg opts: PolygonRestOption): CryptoMultiTickerSnapshotDTO =
         runBlocking { getSnapshotAllTickers(*opts) }
 
     /** See [getSnapshotAllTickersBlocking] */
+    @SafeVarargs
     fun getSnapshotAllTickers(
         callback: PolygonRestApiCallback<CryptoMultiTickerSnapshotDTO>,
         vararg opts: PolygonRestOption
@@ -98,10 +111,12 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/crypto/get_v2_snapshot_locale_global_markets_crypto_tickers__ticker
      */
+    @SafeVarargs
     fun getSnapshotSingleTickerBlocking(ticker: String, vararg opts: PolygonRestOption): CryptoSingleTickerSnapshotDTO =
         runBlocking { getSnapshotSingleTicker(ticker, *opts) }
 
     /** See [getSnapshotSingleTickerBlocking] */
+    @SafeVarargs
     fun getSnapshotSingleTicker(
         ticker: String,
         callback: PolygonRestApiCallback<CryptoSingleTickerSnapshotDTO>,
@@ -114,6 +129,7 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/crypto/get_v2_snapshot_locale_global_markets_crypto__direction
      */
+    @SafeVarargs
     fun getSnapshotGainersOrLosersBlocking(
         direction: GainersOrLosersDirection,
         vararg opts: PolygonRestOption
@@ -121,6 +137,7 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
         runBlocking { getSnapshotGainersOrLosers(direction, *opts) }
 
     /** See [getSnapshotGainersOrLosersBlocking] */
+    @SafeVarargs
     fun getSnapshotGainersOrLosers(
         direction: GainersOrLosersDirection,
         callback: PolygonRestApiCallback<CryptoMultiTickerSnapshotDTO>,
@@ -133,6 +150,7 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/crypto/get_v2_snapshot_locale_global_markets_crypto_tickers__ticker__book
      */
+    @SafeVarargs
     fun getL2SnapshotSingleTickerBlocking(
         ticker: String,
         vararg opts: PolygonRestOption
@@ -140,6 +158,7 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
         runBlocking { getL2SnapshotSingleTicker(ticker, *opts) }
 
     /** See [getL2SnapshotSingleTickerBlocking] */
+    @SafeVarargs
     fun getL2SnapshotSingleTicker(
         ticker: String,
         callback: PolygonRestApiCallback<CryptoTickerL2SnapshotResponseDTO>,

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/crypto/Snapshots.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/crypto/Snapshots.kt
@@ -7,12 +7,14 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /** See [PolygonCryptoClient.getSnapshotAllTickersBlocking] */
+@SafeVarargs
 suspend fun PolygonCryptoClient.getSnapshotAllTickers(vararg opts: PolygonRestOption): CryptoMultiTickerSnapshotDTO =
     polygonClient.fetchResult({
             path("v2", "snapshot", "locale", "global", "markets", "crypto", "tickers")
         }, *opts)
 
 /** See [PolygonCryptoClient.getSnapshotSingleTickerBlocking] */
+@SafeVarargs
 suspend fun PolygonCryptoClient.getSnapshotSingleTicker(ticker: String, vararg opts: PolygonRestOption):
         CryptoSingleTickerSnapshotDTO =
     polygonClient.fetchResult({
@@ -29,6 +31,7 @@ suspend fun PolygonCryptoClient.getSnapshotSingleTicker(ticker: String, vararg o
     }, *opts)
 
 /** See [PolygonCryptoClient.getSnapshotGainersOrLosersBlocking] */
+@SafeVarargs
 suspend fun PolygonCryptoClient.getSnapshotGainersOrLosers(
     direction: GainersOrLosersDirection,
     vararg opts: PolygonRestOption
@@ -46,6 +49,7 @@ suspend fun PolygonCryptoClient.getSnapshotGainersOrLosers(
     }, *opts)
 
 /** See [PolygonCryptoClient.getL2SnapshotSingleTickerBlocking] */
+@SafeVarargs
 suspend fun PolygonCryptoClient.getL2SnapshotSingleTicker(
     ticker: String,
     vararg opts: PolygonRestOption

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/experimental/Financials.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/experimental/Financials.kt
@@ -2,8 +2,8 @@ package io.polygon.kotlin.sdk.rest.experimental
 
 import com.thinkinglogic.builder.annotation.Builder
 import io.ktor.http.*
-import io.polygon.kotlin.sdk.ComparisonQueryFilterParameters
-import io.polygon.kotlin.sdk.applyComparisonQueryFilterParameters
+import io.polygon.kotlin.sdk.rest.ComparisonQueryFilterParameters
+import io.polygon.kotlin.sdk.rest.applyComparisonQueryFilterParameters
 import io.polygon.kotlin.sdk.rest.Paginatable
 import io.polygon.kotlin.sdk.rest.PolygonRestOption
 import kotlinx.serialization.SerialName

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/experimental/Financials.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/experimental/Financials.kt
@@ -10,6 +10,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /** See [PolygonExperimentalClient.getFinancialsBlocking] */
+@SafeVarargs
 @ExperimentalAPI
 suspend fun PolygonExperimentalClient.getFinancials(params: FinancialsParameters, vararg opts: PolygonRestOption): FinancialsResponse =
     polygonClient.fetchResult({

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/forex/HistoricTicks.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/forex/HistoricTicks.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /** See [PolygonForexClient.getHistoricTicksBlocking] */
+@SafeVarargs
 @Deprecated("superseded by getQuotes in PolygonRestClient")
 suspend fun PolygonForexClient.getHistoricTicks(
     params: HistoricTicksParameters,

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/forex/LastQuote.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/forex/LastQuote.kt
@@ -5,6 +5,7 @@ import io.polygon.kotlin.sdk.rest.PolygonRestOption
 import kotlinx.serialization.Serializable
 
 /** See [PolygonForexClient.getLastQuoteBlocking] */
+@SafeVarargs
 suspend fun PolygonForexClient.getLastQuote(
     fromCurrency: String,
     toCurrency: String,

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/forex/PolygonForexClient.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/forex/PolygonForexClient.kt
@@ -4,11 +4,14 @@ import io.polygon.kotlin.sdk.ext.coroutineToRestCallback
 import io.polygon.kotlin.sdk.rest.PolygonRestApiCallback
 import io.polygon.kotlin.sdk.rest.PolygonRestClient
 import io.polygon.kotlin.sdk.rest.PolygonRestOption
+import io.polygon.kotlin.sdk.rest.reference.PolygonReferenceClient
 import io.polygon.kotlin.sdk.rest.stocks.GainersOrLosersDirection
 import kotlinx.coroutines.runBlocking
 
 /**
- * Client for Polygon.io's "Forex / Currencies" RESTful APIs
+ * Client for Polygon.io's forex pricing data RESTful APIs
+ * For common pricing APIs shared across asset classes, see [PolygonRestClient].
+ * For reference data, see [PolygonReferenceClient].
  *
  * You should access this client through [PolygonRestClient]
  */
@@ -22,11 +25,13 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/forex/deprecated/get_v1_historic_forex__from___to___date
      */
+    @SafeVarargs
     @Deprecated("superseded by getQuotesBlocking in PolygonRestClient", ReplaceWith("getQuotesBlocking(params, *opts)"))
     fun getHistoricTicksBlocking(params: HistoricTicksParameters, vararg opts: PolygonRestOption): HistoricTicksDTO =
         runBlocking { getHistoricTicks(params, *opts) }
 
     /** See [getHistoricTicksBlocking] */
+    @SafeVarargs
     @Deprecated("superseded by getQuotes in PolygonRestClient", ReplaceWith("getQuotes(params, callback, *opts)"))
     fun getHistoricTicks(
         params: HistoricTicksParameters,
@@ -40,12 +45,14 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/forex/get_v1_conversion__from___to
      */
+    @SafeVarargs
     fun getRealTimeConversionBlocking(
         params: RealTimeConversionParameters,
         vararg opts: PolygonRestOption
     ): RealTimeConversionDTO = runBlocking { getRealTimeConversion(params, *opts) }
 
     /** See [getRealTimeConversionBlocking] */
+    @SafeVarargs
     fun getRealTimeConversion(
         params: RealTimeConversionParameters,
         callback: PolygonRestApiCallback<RealTimeConversionDTO>,
@@ -57,6 +64,7 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/forex/get_v1_last_quote_currencies__from___to
      */
+    @SafeVarargs
     fun getLastQuoteBlocking(
         fromCurrency: String,
         toCurrency: String,
@@ -64,6 +72,7 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
     ): LastQuoteForexDTO = runBlocking { getLastQuote(fromCurrency, toCurrency, *opts) }
 
     /** See [getLastQuoteBlocking] */
+    @SafeVarargs
     fun getLastQuote(
         fromCurrency: String,
         toCurrency: String,
@@ -78,10 +87,12 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/forex/get_v2_snapshot_locale_global_markets_forex_tickers
      */
+    @SafeVarargs
     fun getSnapshotAllTickersBlocking(vararg opts: PolygonRestOption): SnapshotForexTickersDTO =
         runBlocking { getSnapshotAllTickers(*opts) }
 
     /** See [getSnapshotAllTickersBlocking] */
+    @SafeVarargs
     fun getSnapshotAllTickers(
         callback: PolygonRestApiCallback<SnapshotForexTickersDTO>,
         vararg opts: PolygonRestOption
@@ -92,12 +103,14 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/forex/get_v2_snapshot_locale_global_markets_forex__direction
      */
+    @SafeVarargs
     fun getSnapshotGainersOrLosersBlocking(
         direction: GainersOrLosersDirection,
         vararg opts: PolygonRestOption
     ): SnapshotForexTickersDTO = runBlocking { getSnapshotGainersOrLosers(direction, *opts) }
 
     /** See [getSnapshotGainersOrLosersBlocking] */
+    @SafeVarargs
     fun getSnapshotGainersOrLosers(
         direction: GainersOrLosersDirection,
         callback: PolygonRestApiCallback<SnapshotForexTickersDTO>,

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/forex/RealTimeConversion.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/forex/RealTimeConversion.kt
@@ -7,6 +7,7 @@ import io.polygon.kotlin.sdk.rest.PolygonRestOption
 import kotlinx.serialization.Serializable
 
 /** See [PolygonForexClient.getRealTimeConversionBlocking] */
+@SafeVarargs
 suspend fun PolygonForexClient.getRealTimeConversion(params: RealTimeConversionParameters, vararg opts: PolygonRestOption): RealTimeConversionDTO =
     polygonClient.fetchResult({
         path("v1", "conversion", params.fromCurrency, params.toCurrency)

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/forex/Snapshots.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/forex/Snapshots.kt
@@ -8,11 +8,13 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /** See [PolygonForexClient.getSnapshotAllTickersBlocking] */
+@SafeVarargs
 suspend fun PolygonForexClient.getSnapshotAllTickers(vararg opts: PolygonRestOption): SnapshotForexTickersDTO =
     polygonClient.fetchResult({
         path("v2", "snapshot", "locale", "global", "markets", "forex", "tickers")}, *opts)
 
 /** See [PolygonForexClient.getSnapshotGainersOrLosersBlocking] */
+@SafeVarargs
 suspend fun PolygonForexClient.getSnapshotGainersOrLosers(
     direction: GainersOrLosersDirection,
     vararg opts: PolygonRestOption

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/Conditions.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/Conditions.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /** See [PolygonReferenceClient.getConditionsBlocking] */
+@SafeVarargs
 suspend fun PolygonReferenceClient.getConditions(
     params: ConditionsParameters,
     vararg opts: PolygonRestOption

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/Dividends.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/Dividends.kt
@@ -2,8 +2,8 @@ package io.polygon.kotlin.sdk.rest.reference
 
 import com.thinkinglogic.builder.annotation.Builder
 import io.ktor.http.*
-import io.polygon.kotlin.sdk.ComparisonQueryFilterParameters
-import io.polygon.kotlin.sdk.applyComparisonQueryFilterParameters
+import io.polygon.kotlin.sdk.rest.ComparisonQueryFilterParameters
+import io.polygon.kotlin.sdk.rest.applyComparisonQueryFilterParameters
 import io.polygon.kotlin.sdk.rest.Paginatable
 import io.polygon.kotlin.sdk.rest.PolygonRestOption
 import kotlinx.serialization.SerialName

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/Locales.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/Locales.kt
@@ -5,6 +5,7 @@ import io.polygon.kotlin.sdk.rest.PolygonRestOption
 import kotlinx.serialization.Serializable
 
 /** See [PolygonReferenceClient.getSupportedLocalesBlocking] */
+@SafeVarargs
 @Deprecated("This API is no longer supported and will be sunset some time in the future")
 suspend fun PolygonReferenceClient.getSupportedLocales(vararg opts: PolygonRestOption): LocalesDTO =
     polygonClient.fetchResult({

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/MarketHolidays.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/MarketHolidays.kt
@@ -5,6 +5,7 @@ import io.polygon.kotlin.sdk.rest.PolygonRestOption
 import kotlinx.serialization.Serializable
 
 /** See [PolygonReferenceClient.getMarketHolidaysBlocking] */
+@SafeVarargs
 suspend fun PolygonReferenceClient.getMarketHolidays(vararg opts: PolygonRestOption): List<MarketHolidayDTO> =
     polygonClient.fetchResult({
         path("v1", "marketstatus", "upcoming")

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/MarketStatus.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/MarketStatus.kt
@@ -5,6 +5,7 @@ import io.polygon.kotlin.sdk.rest.PolygonRestOption
 import kotlinx.serialization.Serializable
 
 /** See [PolygonReferenceClient.getMarketStatusBlocking] */
+@SafeVarargs
 suspend fun PolygonReferenceClient.getMarketStatus(vararg opts: PolygonRestOption): MarketStatusDTO =
     polygonClient.fetchResult({
         path("v1", "marketstatus", "now")

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/Markets.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/Markets.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /** See [PolygonReferenceClient.getSupportedMarketsBlocking] */
+@SafeVarargs
 @Deprecated("This API is no longer supported and will be sunset some time in the future")
 suspend fun PolygonReferenceClient.getSupportedMarkets(vararg opts: PolygonRestOption): MarketsDTO =
     polygonClient.fetchResult({

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/OptionsContracts.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/OptionsContracts.kt
@@ -2,10 +2,10 @@ package io.polygon.kotlin.sdk.rest.reference
 
 import com.thinkinglogic.builder.annotation.Builder
 import io.ktor.http.*
-import io.polygon.kotlin.sdk.ComparisonQueryFilterParameters
-import io.polygon.kotlin.sdk.applyComparisonQueryFilterParameters
+import io.polygon.kotlin.sdk.rest.ComparisonQueryFilterParameters
 import io.polygon.kotlin.sdk.rest.Paginatable
 import io.polygon.kotlin.sdk.rest.PolygonRestOption
+import io.polygon.kotlin.sdk.rest.applyComparisonQueryFilterParameters
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/PolygonReferenceClient.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/PolygonReferenceClient.kt
@@ -17,10 +17,12 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/stocks/get_v3_reference_tickers
      */
+    @SafeVarargs
     fun getSupportedTickersBlocking(params: SupportedTickersParameters, vararg opts: PolygonRestOption): TickersDTO =
         runBlocking { getSupportedTickers(params, *opts) }
 
     /** See [getSupportedTickersBlocking] */
+    @SafeVarargs
     fun getSupportedTickers(
         params: SupportedTickersParameters,
         callback: PolygonRestApiCallback<TickersDTO>,
@@ -50,11 +52,13 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/#!/Reference/get_v2_reference_types
      */
+    @SafeVarargs
     @Deprecated("use getTickerTypesBlocking instead")
     fun getSupportedTickerTypesBlocking(vararg opts: PolygonRestOption): TickerTypesDTO =
         runBlocking { getSupportedTickerTypes(*opts) }
 
     /** See [getSupportedTickerTypesBlocking] */
+    @SafeVarargs
     @Deprecated("use getTickerTypes instead")
     fun getSupportedTickerTypes(callback: PolygonRestApiCallback<TickerTypesDTO>, vararg opts: PolygonRestOption) {
         coroutineToRestCallback(callback, { getSupportedTickerTypes(*opts) })
@@ -85,6 +89,7 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/#!/Reference/get_v1_meta_symbols_symbol_company
      */
+    @SafeVarargs
     @Deprecated(
         "supserseded by getTickerDetailsV3Blocking and will be replaced in a future verison",
         ReplaceWith("getTickerDetailsV3Blocking(symbol, params, *opts)")
@@ -93,6 +98,7 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
         runBlocking { getTickerDetails(symbol, *opts) }
 
     /** See [getTickerDetailsBlocking] */
+    @SafeVarargs
     @Deprecated("supserseded by getTickerDetailsV3 and will be replaced in a future verison", ReplaceWith("getTickerDetailsV3(symbol, params, *opts)"))
     fun getTickerDetails(
         symbol: String,
@@ -110,6 +116,7 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/stocks/get_v3_reference_tickers__ticker
      */
+    @SafeVarargs
     fun getTickerDetailsV3Blocking(
         ticker: String,
         params: TickerDetailsParameters,
@@ -118,6 +125,7 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
         runBlocking { getTickerDetailsV3(ticker, params, *opts) }
 
     /** See [getTickerDetailsV3Blocking] */
+    @SafeVarargs
     fun getTickerDetailsV3(
         ticker: String,
         params: TickerDetailsParameters,
@@ -131,6 +139,7 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/#!/Reference/get_v1_meta_symbols_symbol_news
      */
+    @SafeVarargs
     @Deprecated(
         "superseded by getTickerNewsBlockingV2 and listTickerNewsV2",
         ReplaceWith("getTickerNewsBlockingV2(params, *opts)")
@@ -139,6 +148,7 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
         runBlocking { getTickerNews(params, *opts) }
 
     /** See [getTickerNewsBlocking] */
+    @SafeVarargs
     @Deprecated(
         "superseded by getTickerNewsV2 and listTickerNewsV2",
         ReplaceWith("getTickerNewsV2(params, *opts)")
@@ -189,11 +199,13 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/#!/Reference/get_v2_reference_markets
      */
+    @SafeVarargs
     @Deprecated("This API is no longer supported and will be sunset some time in the future")
     fun getSupportedMarketsBlocking(vararg opts: PolygonRestOption): MarketsDTO =
         runBlocking { getSupportedMarkets(*opts) }
 
     /** See [getSupportedMarketsBlocking] */
+    @SafeVarargs
     @Deprecated("This API is no longer supported and will be sunset some time in the future")
     fun getSupportedMarkets(callback: PolygonRestApiCallback<MarketsDTO>, vararg opts: PolygonRestOption) {
         coroutineToRestCallback(callback, { getSupportedMarkets(*opts) })
@@ -204,11 +216,13 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/#!/Reference/get_v2_reference_locales
      */
+    @SafeVarargs
     @Deprecated("This API is no longer supported and will be sunset some time in the future")
     fun getSupportedLocalesBlocking(vararg opts: PolygonRestOption): LocalesDTO =
         runBlocking { getSupportedLocales(*opts) }
 
     /** See [getSupportedLocalesBlocking] */
+    @SafeVarargs
     @Deprecated("This API is no longer supported and will be sunset some time in the future")
     fun getSupportedLocales(callback: PolygonRestApiCallback<LocalesDTO>, vararg opts: PolygonRestOption) {
         coroutineToRestCallback(callback, { getSupportedLocales(*opts) })
@@ -219,11 +233,13 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/#!/Reference/get_v2_reference_splits_symbol
      */
+    @SafeVarargs
     @Deprecated("use getSplitsBlocking or listSplits instead", ReplaceWith("getSplitsBlocking(params, *opts)"))
     fun getStockSplitsBlocking(symbol: String, vararg opts: PolygonRestOption): StockSplitsDTO =
         runBlocking { getStockSplits(symbol, *opts) }
 
     /** See [getStockSplitsBlocking] */
+    @SafeVarargs
     @Deprecated("use getSplits or listSplits instead", ReplaceWith("getSplits(params, callback, *opts)"))
     fun getStockSplits(
         symbol: String,
@@ -238,10 +254,12 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/stocks/get_v3_reference_splits
      */
+    @SafeVarargs
     fun getSplitsBlocking(params: SplitsParameters, vararg opts: PolygonRestOption): SplitsResponse =
         runBlocking { getSplits(params, *opts) }
 
     /** See [getSplitsBlocking] */
+    @SafeVarargs
     fun getSplits(
         params: SplitsParameters,
         callback: PolygonRestApiCallback<SplitsResponse>,
@@ -267,11 +285,13 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/#!/Reference/get_v2_reference_dividends_symbol
      */
+    @SafeVarargs
     @Deprecated("use getDividendsBlocking or listDividends", ReplaceWith("getDividendsBlocking(params, *opts)"))
     fun getStockDividendsBlocking(symbol: String, vararg opts: PolygonRestOption): StockDividendsDTO =
         runBlocking { getStockDividends(symbol, *opts) }
 
     /** See [getStockDividendsBlocking] */
+    @SafeVarargs
     @Deprecated("use getDividends or listDividends", ReplaceWith("getDividends(params, callback, *opts)"))
     fun getStockDividends(
         symbol: String,
@@ -317,6 +337,7 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/#!/Reference/get_v2_reference_financials_symbol
      */
+    @SafeVarargs
     @Deprecated(
         "This API is deprecated and will be sunset some time in the future. " +
                 "It will be replaced by the experimental financials API (see PolygonExerimentalClient.getFinancialsBlocking)"
@@ -328,6 +349,7 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
         runBlocking { getStockFinancials(params, *opts) }
 
     /** See [getStockFinancialsBlocking] */
+    @SafeVarargs
     @Deprecated(
         "This API is deprecated and will be sunset some time in the future. " +
                 "It will be replaced by the experimental financials API (see PolygonExerimentalClient.getFinancials)"
@@ -344,10 +366,12 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/stocks/get_v1_marketstatus_now
      */
+    @SafeVarargs
     fun getMarketStatusBlocking(vararg opts: PolygonRestOption): MarketStatusDTO =
         runBlocking { getMarketStatus(*opts) }
 
     /** See [getMarketStatusBlocking] */
+    @SafeVarargs
     fun getMarketStatus(callback: PolygonRestApiCallback<MarketStatusDTO>, vararg opts: PolygonRestOption) =
         coroutineToRestCallback(callback, { getMarketStatus(*opts) })
 
@@ -356,10 +380,12 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/stocks/get_v1_marketstatus_upcoming
      */
+    @SafeVarargs
     fun getMarketHolidaysBlocking(vararg opts: PolygonRestOption): List<MarketHolidayDTO> =
         runBlocking { getMarketHolidays(*opts) }
 
     /** See [getMarketHolidaysBlocking] */
+    @SafeVarargs
     fun getMarketHolidays(callback: PolygonRestApiCallback<List<MarketHolidayDTO>>, vararg opts: PolygonRestOption) =
         coroutineToRestCallback(callback, { getMarketHolidays(*opts) })
 
@@ -368,6 +394,7 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/stocks/get_v3_reference_conditions
      */
+    @SafeVarargs
     fun getConditionsBlocking(params: ConditionsParameters, vararg opts: PolygonRestOption): ConditionsResponse =
         runBlocking { getConditions(params, *opts) }
 

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/Splits.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/Splits.kt
@@ -2,8 +2,8 @@ package io.polygon.kotlin.sdk.rest.reference
 
 import com.thinkinglogic.builder.annotation.Builder
 import io.ktor.http.*
-import io.polygon.kotlin.sdk.ComparisonQueryFilterParameters
-import io.polygon.kotlin.sdk.applyComparisonQueryFilterParameters
+import io.polygon.kotlin.sdk.rest.ComparisonQueryFilterParameters
+import io.polygon.kotlin.sdk.rest.applyComparisonQueryFilterParameters
 import io.polygon.kotlin.sdk.rest.Paginatable
 import io.polygon.kotlin.sdk.rest.PolygonRestOption
 import kotlinx.serialization.SerialName

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/StockDividends.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/StockDividends.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /** See [PolygonReferenceClient.getStockDividendsBlocking] */
+@SafeVarargs
 @Deprecated("use getDividends or listDividends", ReplaceWith("getDividends(params, *opts)"))
 suspend fun PolygonReferenceClient.getStockDividends(
     symbol: String,

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/StockFinancials.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/StockFinancials.kt
@@ -6,6 +6,7 @@ import io.polygon.kotlin.sdk.rest.PolygonRestOption
 import kotlinx.serialization.Serializable
 
 /** See [PolygonReferenceClient.getStockFinancialsBlocking] */
+@SafeVarargs
 @Deprecated(
     "This API is deprecated and will be sunset some time in the future. " +
             "It will be replaced by the experimental financials API (see PolygonExerimentalClient.getFinancials)"

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/StockSplits.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/StockSplits.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /** See [PolygonReferenceClient.getStockSplitsBlocking] */
+@SafeVarargs
 @Deprecated("use getSplits or listSplits instead", ReplaceWith("getSplits(params, *opts)"))
 suspend fun PolygonReferenceClient.getStockSplits(symbol: String, vararg opts: PolygonRestOption): StockSplitsDTO =
     polygonClient.fetchResult({

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/TickerDetails.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/TickerDetails.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /** See [PolygonReferenceClient.getTickerDetailsV3Blocking] */
+@SafeVarargs
 suspend fun PolygonReferenceClient.getTickerDetailsV3(ticker: String, params: TickerDetailsParameters, vararg opts: PolygonRestOption): TickerDetailsResponse =
     polygonClient.fetchResult({
         path("v3", "reference", "tickers", ticker)

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/TickerNews.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/TickerNews.kt
@@ -3,8 +3,8 @@ package io.polygon.kotlin.sdk.rest.reference
 import com.thinkinglogic.builder.annotation.Builder
 import com.thinkinglogic.builder.annotation.DefaultValue
 import io.ktor.http.*
-import io.polygon.kotlin.sdk.ComparisonQueryFilterParameters
-import io.polygon.kotlin.sdk.applyComparisonQueryFilterParameters
+import io.polygon.kotlin.sdk.rest.ComparisonQueryFilterParameters
+import io.polygon.kotlin.sdk.rest.applyComparisonQueryFilterParameters
 import io.polygon.kotlin.sdk.rest.Paginatable
 import io.polygon.kotlin.sdk.rest.PolygonRestOption
 import kotlinx.serialization.SerialName

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/Tickers.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/reference/Tickers.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /** See [PolygonReferenceClient.getSupportedTickersBlocking] */
+@SafeVarargs
 suspend fun PolygonReferenceClient.getSupportedTickers(
     params: SupportedTickersParameters,
     vararg opts: PolygonRestOption

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/ConditionMappings.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/ConditionMappings.kt
@@ -4,6 +4,7 @@ import io.ktor.http.*
 import io.polygon.kotlin.sdk.rest.PolygonRestOption
 
 /** See [PolygonStocksClient.getConditionMappingsBlocking] */
+@SafeVarargs
 @Deprecated("use getConditions in PolygonReferenceClient instead")
 suspend fun PolygonStocksClient.getConditionMappings(
     type: ConditionMappingTickerType,

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/DailyOpenClose.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/DailyOpenClose.kt
@@ -5,6 +5,7 @@ import io.polygon.kotlin.sdk.rest.PolygonRestOption
 import kotlinx.serialization.Serializable
 
 /** See [PolygonStocksClient.getDailyOpenCloseBlocking] */
+@SafeVarargs
 suspend fun PolygonStocksClient.getDailyOpenClose(
     symbol: String,
     date: String,

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/Exchanges.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/Exchanges.kt
@@ -5,6 +5,7 @@ import io.polygon.kotlin.sdk.rest.PolygonRestOption
 import kotlinx.serialization.Serializable
 
 /** See [PolygonStocksClient.getSupportedExchangesBlocking] */
+@SafeVarargs
 suspend fun PolygonStocksClient.getSupportedExchanges(vararg opts: PolygonRestOption): List<ExchangeDTO> =
     polygonClient.fetchResult({ path("v1", "meta", "exchanges") }, *opts)
 

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/HistoricQuotes.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/HistoricQuotes.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /** See [PolygonStocksClient.getHistoricQuotesBlocking] */
+@SafeVarargs
 @Deprecated("superseded by getQuotes in PolygonRestCLient")
 suspend fun PolygonStocksClient.getHistoricQuotes(
     params: HistoricQuotesParameters,

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/HistoricTrades.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/HistoricTrades.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /** See [PolygonStocksClient.getHistoricTradesBlocking] */
+@SafeVarargs
 @Deprecated("superseded by getTrades in PolygonRestClient")
 suspend fun PolygonStocksClient.getHistoricTrades(
     params: HistoricTradesParameters,

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/LastQuote.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/LastQuote.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /** See [PolygonStocksClient.getLastQuoteBlocking] */
+@SafeVarargs
 @Deprecated("superseded by getLastQuoteV2 and will be replaced in a future verison")
 suspend fun PolygonStocksClient.getLastQuote(symbol: String, vararg opts: PolygonRestOption): LastQuoteResultDTO =
     polygonClient.fetchResult({ path("v1", "last_quote", "stocks", symbol) }, *opts)

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/LastTrade.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/LastTrade.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /** See [PolygonStocksClient.getLastTradeBlocking] */
+@SafeVarargs
 @Deprecated("superseded by getLastTradeV2 and will be replaced in a future version")
 suspend fun PolygonStocksClient.getLastTrade(symbol: String, vararg opts: PolygonRestOption): LastTradeResultDTO =
     polygonClient.fetchResult({ path("v1", "last", "stocks", symbol) }, *opts)

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/PolygonStocksClient.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/PolygonStocksClient.kt
@@ -4,10 +4,13 @@ import io.polygon.kotlin.sdk.ext.coroutineToRestCallback
 import io.polygon.kotlin.sdk.rest.PolygonRestApiCallback
 import io.polygon.kotlin.sdk.rest.PolygonRestClient
 import io.polygon.kotlin.sdk.rest.PolygonRestOption
+import io.polygon.kotlin.sdk.rest.reference.PolygonReferenceClient
 import kotlinx.coroutines.runBlocking
 
 /**
- * Client for Polygon.io's "Stocks / Equities" RESTful APIs
+ * Client for Polygon.io's "Stocks / Equities" pricing data RESTful APIs
+ * For common pricing APIs shared across asset classes, see [PolygonRestClient].
+ * For reference data, see [PolygonReferenceClient].
  *
  * You should access this client through [PolygonRestClient]
  */
@@ -19,10 +22,12 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/#!/Stocks--Equities/get_v1_meta_exchanges
      */
+    @SafeVarargs
     fun getSupportedExchangesBlocking(vararg opts: PolygonRestOption): List<ExchangeDTO> =
         runBlocking { getSupportedExchanges(*opts) }
 
     /** See [getSupportedExchangesBlocking] */
+    @SafeVarargs
     fun getSupportedExchanges(callback: PolygonRestApiCallback<List<ExchangeDTO>>, vararg opts: PolygonRestOption) =
         coroutineToRestCallback(callback, { getSupportedExchanges(*opts) })
 
@@ -31,11 +36,13 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/#!/Stocks--Equities/get_v2_ticks_stocks_trades_ticker_date
      */
+    @SafeVarargs
     @Deprecated("use listTrades or getTradesBlocking in PolygonRestClient", ReplaceWith("listTrades(params, *opts)"))
     fun getHistoricTradesBlocking(params: HistoricTradesParameters, vararg opts: PolygonRestOption): HistoricTradesDTO =
         runBlocking { getHistoricTrades(params, *opts) }
 
     /** See [getHistoricTradesBlocking] */
+    @SafeVarargs
     @Deprecated("use listTrades or getTrades in PolygonRestClient", ReplaceWith("listTrades(params, *opts)"))
     fun getHistoricTrades(
         params: HistoricTradesParameters,
@@ -49,11 +56,13 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/#!/Stocks--Equities/get_v2_ticks_stocks_nbbo_ticker_date
      */
+    @SafeVarargs
     @Deprecated("superseded by listQuotes/getQuotesBlocking in PolygonRestClient",ReplaceWith("getQuotesBlocking(params, *ops)"))
     fun getHistoricQuotesBlocking(params: HistoricQuotesParameters, vararg opts: PolygonRestOption): HistoricQuotesDTO =
         runBlocking { getHistoricQuotes(params, *opts) }
 
     /** See [getHistoricQuotesBlocking] */
+    @SafeVarargs
     @Deprecated("superseded by listQuotes/getQuotes in PolygonRestClient",ReplaceWith("getQuotes(params, callback, *ops)"))
     fun getHistoricQuotes(
         params: HistoricQuotesParameters,
@@ -67,11 +76,13 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/#!/Stocks--Equities/get_v1_last_stocks_symbol
      */
+    @SafeVarargs
     @Deprecated("superseded by getLastTradeV2 and will be replaced in a future version", ReplaceWith("getLastTradeV2(ticker, *opts)"))
     fun getLastTradeBlocking(symbol: String, vararg opts: PolygonRestOption): LastTradeResultDTO =
         runBlocking { getLastTrade(symbol, *opts) }
 
     /** See [getLastTradeBlocking] */
+    @SafeVarargs
     @Deprecated("replaced by getLastTradeV2", ReplaceWith("getLastTradeV2(ticker, callback, *opts)"))
     fun getLastTrade(
         symbol: String,
@@ -87,9 +98,12 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/stocks/get_v2_last_trade__stocksticker
      */
+    @SafeVarargs
     fun getLastTradeBlockingV2(ticker: String, vararg opts: PolygonRestOption): LastTradeResultV2 =
         runBlocking { getLastTradeV2(ticker, *opts) }
 
+    /** See [getLastTradeBlockingV2] */
+    @SafeVarargs
     fun getLastTradeV2(ticker: String, callback: PolygonRestApiCallback<LastTradeResultV2>, vararg opts: PolygonRestOption) =
         coroutineToRestCallback(callback, { getLastTradeV2(ticker, *opts)} )
 
@@ -98,11 +112,13 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/#!/Stocks--Equities/get_v1_last_quote_stocks_symbol
      */
+    @SafeVarargs
     @Deprecated("superseded by getLastQuoteBlockingV2", ReplaceWith("getLastQuoteBlockingV2(ticker, *opts)"))
     fun getLastQuoteBlocking(symbol: String, vararg opts: PolygonRestOption): LastQuoteResultDTO =
         runBlocking { getLastQuote(symbol, *opts) }
 
     /** See [getLastQuoteBlocking] */
+    @SafeVarargs
     @Deprecated("superseded by getLastQuoteV2", ReplaceWith("getLastQuoteV2(ticker, callback, *opts)"))
     fun getLastQuote(
         symbol: String,
@@ -116,9 +132,12 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/stocks/get_v2_last_nbbo__stocksticker
      */
+    @SafeVarargs
     fun getLastQuoteBlockingV2(ticker: String, vararg opts: PolygonRestOption): LastQuoteResultV2 =
         runBlocking { getLastQuoteV2(ticker, *opts) }
 
+    /** See [getLastQuoteBlockingV2] */
+    @SafeVarargs
     fun getLastQuoteV2(ticker: String, callback: PolygonRestApiCallback<LastQuoteResultV2>, vararg opts: PolygonRestOption) =
         coroutineToRestCallback(callback, { getLastQuoteV2(ticker, *opts)} )
 
@@ -128,6 +147,7 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/stocks/get_v1_open-close__stocksticker___date
      */
+    @SafeVarargs
     fun getDailyOpenCloseBlocking(
         symbol: String,
         date: String,
@@ -137,6 +157,7 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
         runBlocking { getDailyOpenClose(symbol, date, unadjusted, *opts) }
 
     /** See [getDailyOpenCloseBlocking] */
+    @SafeVarargs
     fun getDailyOpenClose(
         symbol: String,
         date: String,
@@ -151,6 +172,7 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/#!/Stocks--Equities/get_v1_meta_conditions_ticktype
      */
+    @SafeVarargs
     @Deprecated("use getConditions in PolygonReferenceClient instead")
     fun getConditionMappingsBlocking(
         tickType: ConditionMappingTickerType,
@@ -159,6 +181,7 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
         runBlocking { getConditionMappings(tickType, *opts) }
 
     /** See [getConditionMappingsBlocking] */
+    @SafeVarargs
     @Deprecated("use getConditions in PolygonReferenceClient instead")
     fun getConditionMappings(
         tickType: ConditionMappingTickerType,
@@ -174,10 +197,12 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/stocks/get_v2_snapshot_locale_us_markets_stocks_tickers
      */
+    @SafeVarargs
     fun getSnapshotAllTickersBlocking(vararg opts: PolygonRestOption): SnapshotAllTickersDTO =
         runBlocking { getSnapshotAllTickers(*opts) }
 
     /** See [getSnapshotAllTickersBlocking] */
+    @SafeVarargs
     fun getSnapshotAllTickers(callback: PolygonRestApiCallback<SnapshotAllTickersDTO>, vararg opts: PolygonRestOption) =
         coroutineToRestCallback(callback, { getSnapshotAllTickers(*opts) })
 
@@ -186,10 +211,12 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/stocks/get_v2_snapshot_locale_us_markets_stocks_tickers__stocksticker
      */
+    @SafeVarargs
     fun getSnapshotBlocking(symbol: String, vararg opts: PolygonRestOption): SnapshotSingleTickerDTO =
         runBlocking { getSnapshot(symbol, *opts) }
 
     /** See [getSnapshotBlocking] */
+    @SafeVarargs
     fun getSnapshot(
         symbol: String,
         callback: PolygonRestApiCallback<SnapshotSingleTickerDTO>,
@@ -202,6 +229,7 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/stocks/get_v2_snapshot_locale_us_markets_stocks__direction
      */
+    @SafeVarargs
     fun getSnapshotGainersOrLosersBlocking(
         direction: GainersOrLosersDirection,
         vararg opts: PolygonRestOption
@@ -209,6 +237,7 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
         runBlocking { getSnapshotGainersOrLosers(direction, *opts) }
 
     /** See [getSnapshotGainersOrLosersBlocking] */
+    @SafeVarargs
     fun getSnapshotGainersOrLosers(
         direction: GainersOrLosersDirection,
         callback: PolygonRestApiCallback<SnapshotGainersOrLosersDTO>,
@@ -223,6 +252,7 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      *
      * API Doc: https://polygon.io/docs/stocks/get_v2_aggs_ticker__stocksticker__prev
      */
+    @SafeVarargs
     fun getPreviousCloseBlocking(
         symbol: String,
         unadjusted: Boolean,
@@ -231,6 +261,7 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
         runBlocking { getPreviousClose(symbol, unadjusted, *opts) }
 
     /** See [getPreviousCloseBlocking] */
+    @SafeVarargs
     fun getPreviousClose(
         symbol: String,
         unadjusted: Boolean,

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/PreviousClose.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/PreviousClose.kt
@@ -6,6 +6,7 @@ import io.polygon.kotlin.sdk.rest.PolygonRestOption
 import kotlinx.serialization.Serializable
 
 /** See [PolygonStocksClient.getPreviousCloseBlocking] */
+@SafeVarargs
 suspend fun PolygonStocksClient.getPreviousClose(
     symbol: String,
     unadjusted: Boolean = false,

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/Snapshots.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/stocks/Snapshots.kt
@@ -6,18 +6,21 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /** See [PolygonStocksClient.getSnapshotAllTickersBlocking] */
+@SafeVarargs
 suspend fun PolygonStocksClient.getSnapshotAllTickers(vararg opts: PolygonRestOption): SnapshotAllTickersDTO =
     polygonClient.fetchResult({
         path("v2", "snapshot", "locale", "us", "markets", "stocks", "tickers")
     }, *opts)
 
 /** See [PolygonStocksClient.getSnapshotBlocking] */
+@SafeVarargs
 suspend fun PolygonStocksClient.getSnapshot(symbol: String, vararg opts: PolygonRestOption): SnapshotSingleTickerDTO =
     polygonClient.fetchResult({
         path("v2", "snapshot", "locale", "us", "markets", "stocks", "tickers", symbol)
     }, *opts)
 
 /** See [PolygonStocksClient.getSnapshotGainersOrLosersBlocking] */
+@SafeVarargs
 suspend fun PolygonStocksClient.getSnapshotGainersOrLosers(
     direction: GainersOrLosersDirection,
     vararg opts: PolygonRestOption


### PR DESCRIPTION
`@SafeVarargs` indicates to Java code that the library code safely accesses the vararg parameter in the function. Since we only pass through and iterate over the `opts` param, we aren't doing anything unsafe.