### PR TITLE
add maven-publish gradle plugin for jitpack publishing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,7 @@ buildscript {
 
 plugins {
     `java-library`
+    `maven-publish`
     kotlin("jvm") version "1.6.10"
     kotlin("plugin.serialization") version "1.6.10"
     kotlin("kapt") version "1.6.10"


### PR DESCRIPTION
This adds the necessary task for jitpack to be able to distribute the library for us. It was originally in the `maven` plugin, but that got deprecated and was supposed to be replaced by `maven-publish`, but it got left out when we removed `maven` earlier.