### PR TITLE
Added experimental ticker events

### DIFF
--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/experimental/Events.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/experimental/Events.kt
@@ -17,21 +17,6 @@ suspend fun PolygonExperimentalClient.getTickerEvents(id: String, types: String?
         types?.let { parameters["types"] = it }
     }, *opts)
 
-@Builder
-@ExperimentalAPI
-data class TickerEventsParameters(
-
-    /**
-     * Identifier of an asset. This can currently be a Ticker, CUSIP, or Composite FIGI.
-     */
-    val id: String,
-
-    /**
-     * A comma-separated list of the types of event to include. Currently ticker_change is the only supported event_type. Leave blank to return all supported event_types.
-     */
-    val types: String? = null
-)
-
 @Serializable
 @ExperimentalAPI
 data class TickerEventsResponse(

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/experimental/Events.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/experimental/Events.kt
@@ -1,0 +1,66 @@
+package io.polygon.kotlin.sdk.rest.experimental
+
+import com.thinkinglogic.builder.annotation.Builder
+import io.ktor.http.*
+import io.polygon.kotlin.sdk.rest.ComparisonQueryFilterParameters
+import io.polygon.kotlin.sdk.rest.applyComparisonQueryFilterParameters
+import io.polygon.kotlin.sdk.rest.Paginatable
+import io.polygon.kotlin.sdk.rest.PolygonRestOption
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@SafeVarargs
+@ExperimentalAPI
+suspend fun PolygonExperimentalClient.getTickerEvents(params: TickerEventsParameters, vararg opts: PolygonRestOption): TickerEventsResponse =
+    polygonClient.fetchResult({
+        path("vX", "reference", "tickers", params.id, "events")
+
+        params.types?.let { parameters["types"] = it }
+
+    }, *opts)
+
+@Builder
+@ExperimentalAPI
+data class TickerEventsParameters(
+
+    /**
+     * Identifier of an asset. This can currently be a Ticker, CUSIP, or Composite FIGI.
+     */
+    val id: String,
+
+    /**
+     * A comma-separated list of the types of event to include. Currently ticker_change is the only supported event_type. Leave blank to return all supported event_types.
+     */
+    val types: String? = null
+)
+
+@Serializable
+@ExperimentalAPI
+data class TickerEventsResponse(
+    val status: String? = null,
+    @SerialName("request_id") val requestID: String? = null,
+    val results: TickerEvents? = null
+)
+
+@Serializable
+@ExperimentalAPI
+data class TickerEvents(
+    val name: String = "",
+    @SerialName("composite_figi") val compositeFigi: String = "",
+    val cik: String = "",
+    val events: List<TickerEvent>? = null
+)
+
+@Serializable
+@ExperimentalAPI
+data class TickerEvent(
+    @SerialName("ticker_change") val tickerChange: TickerChange? = null,
+    val type: String? = null,
+    val date: String? = null
+)
+
+@Serializable
+@ExperimentalAPI
+data class TickerChange(
+    val ticker: String? = null
+)

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/experimental/Events.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/experimental/Events.kt
@@ -11,12 +11,10 @@ import kotlinx.serialization.Serializable
 
 @SafeVarargs
 @ExperimentalAPI
-suspend fun PolygonExperimentalClient.getTickerEvents(params: TickerEventsParameters, vararg opts: PolygonRestOption): TickerEventsResponse =
+suspend fun PolygonExperimentalClient.getTickerEvents(id: String, types: String? = null, vararg opts: PolygonRestOption): TickerEventsResponse =
     polygonClient.fetchResult({
-        path("vX", "reference", "tickers", params.id, "events")
-
-        params.types?.let { parameters["types"] = it }
-
+        path("vX", "reference", "tickers", id, "events")
+        types?.let { parameters["types"] = it }
     }, *opts)
 
 @Builder

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/experimental/PolygonExperimentalClient.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/experimental/PolygonExperimentalClient.kt
@@ -51,4 +51,27 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
             polygonClient.requestIteratorFetch<FinancialsResponse>(*opts)
         )
 
+    /**
+     * GGet a timeline of events for the entity associated with the given ticker, 
+     * CUSIP, or Composite FIGI.
+     *
+     * This API is experimental. The contract may change without a major version update.
+     */
+	@SafeVarargs
+	@ExperimentalAPI
+	fun getTickerEventsBlocking(params: TickerEventsParameters, vararg opts: PolygonRestOption): TickerEventsResponse =
+	    runBlocking { getTickerEvents(params, *opts) }
+
+	/** See [getTickerEventsBlocking] */
+	@SafeVarargs
+	@ExperimentalAPI
+	fun getTickerEvents(
+	    params: TickerEventsParameters,
+	    callback: PolygonRestApiCallback<TickerEventsResponse>,
+	    vararg opts: PolygonRestOption
+	) =
+	    coroutineToRestCallback(callback, { getTickerEvents(params, *opts) })
+
+
+
 }

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/experimental/PolygonExperimentalClient.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/experimental/PolygonExperimentalClient.kt
@@ -59,19 +59,18 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
      */
 	@SafeVarargs
 	@ExperimentalAPI
-	fun getTickerEventsBlocking(params: TickerEventsParameters, vararg opts: PolygonRestOption): TickerEventsResponse =
-	    runBlocking { getTickerEvents(params, *opts) }
+	fun getTickerEventsBlocking(id: String, types: String? = null, vararg opts: PolygonRestOption): TickerEventsResponse =
+	    runBlocking { getTickerEvents(id, types, *opts) }
 
 	/** See [getTickerEventsBlocking] */
 	@SafeVarargs
 	@ExperimentalAPI
 	fun getTickerEvents(
-	    params: TickerEventsParameters,
+	    id: String,
+	    types: String? = null,
 	    callback: PolygonRestApiCallback<TickerEventsResponse>,
 	    vararg opts: PolygonRestOption
 	) =
-	    coroutineToRestCallback(callback, { getTickerEvents(params, *opts) })
-
-
+	    coroutineToRestCallback(callback, { getTickerEvents(id, types, *opts) })
 
 }

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/experimental/PolygonExperimentalClient.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/experimental/PolygonExperimentalClient.kt
@@ -52,7 +52,7 @@ internal constructor(internal val polygonClient: PolygonRestClient) {
         )
 
     /**
-     * GGet a timeline of events for the entity associated with the given ticker, 
+     * Get a timeline of events for the entity associated with the given ticker,
      * CUSIP, or Composite FIGI.
      *
      * This API is experimental. The contract may change without a major version update.


### PR DESCRIPTION
Added the stocks ticker events experimental endpoint.

Running something like this:

```kotlin
// Stocks Ticker Events (experimental)
// https://polygon.io/docs/stocks/get_vx_reference_tickers__id__events
fun stocksTickerEvents(polygonClient: PolygonRestClient) {
    println("META events:")
    polygonClient.experimentalClient.getTickerEventsBlocking(TickerEventsParameters(id = "META")).pp()
}
```

Will print this:

```
TickerEventsResponse(
  Companion = Companion(
  )
  status = "OK"
  requestID = "4c65f82386fd8a8e4c4a5065cf27eabb"
  results = TickerEvents(
    Companion = Companion(
    )
    name = "Meta Platforms, Inc. Class A Common Stock"
    compositeFigi = "BBG000MM2P62"
    cik = "0001326801"
    events = [
               TickerEvent(
                 Companion = Companion(
                 )
                 tickerChange = TickerChange(
                   Companion = Companion(
                   )
                   ticker = "META"
                 )
                 type = "ticker_change"
                 date = "2022-06-09"
               ),
               TickerEvent(
                 Companion = Companion(
                 )
                 tickerChange = TickerChange(
                   Companion = Companion(
                   )
                   ticker = "FB"
                 )
                 type = "ticker_change"
                 date = "2012-05-18"
               )
             ]
  )
)
```