### PR TITLE
use a sealed class for Feed to support a dynamic 'other' option

### DIFF
--- a/sample/src/main/java/io/polygon/kotlin/sdk/sample/JavaUsageSample.java
+++ b/sample/src/main/java/io/polygon/kotlin/sdk/sample/JavaUsageSample.java
@@ -73,7 +73,7 @@ public class JavaUsageSample {
     public static void websocketSample(String polygonKey) {
         PolygonWebSocketClient client = new PolygonWebSocketClient(
                 polygonKey,
-                Feed.RealTime,
+                Feed.RealTime.INSTANCE,
                 Market.Crypto,
                 new DefaultPolygonWebSocketListener() {
                     @Override

--- a/src/main/kotlin/io/polygon/kotlin/sdk/websocket/PolygonWebSocketClient.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/websocket/PolygonWebSocketClient.kt
@@ -22,14 +22,19 @@ private const val EVENT_TYPE_MESSAGE_KEY = "ev"
 /**
  * Feed is the data feed (e.g. Delayed, RealTime) which represents the server host.
  */
-enum class Feed(val url: String) {
-    Delayed("delayed.polygon.io"),
-    RealTime("socket.polygon.io"),
-    Nasdaq("nasdaqfeed.polygon.io"),
-    PolyFeed("polyfeed.polygon.io"),
-    PolyFeedPlus("polyfeedplus.polygon.io"),
-    StarterFeed("starterfeed.polygon.io"),
-    LaunchpadFeed("launchpad.polygon.io")
+sealed class Feed(val url: String) {
+    object Delayed : Feed("delayed.polygon.io")
+    object RealTime : Feed("socket.polygon.io")
+    object Nasdaq : Feed("nasdaqfeed.polygon.io")
+    object PolyFeed : Feed("polyfeed.polygon.io")
+    object PolyFeedPlus : Feed("polyfeedplus.polygon.io")
+    object StarterFeed : Feed("starterfeed.polygon.io")
+    object LaunchpadFeed : Feed("launchpad.polygon.io")
+
+    /**
+     * Use Other if there's a new feed that this client library doesn't yet support.
+     */
+    class Other(url: String) : Feed(url)
 }
 
 /**


### PR DESCRIPTION
Experimenting with how it would look to use a sealed class instead of an enum for `Feed`. This would let us support a dynamic "other" attribute to make the SDK more flexible for when we add new feed types. I see this benefit as two-fold: 
1. If _we_ don't update our SDK to include a new Feed type right away, users can still use this SDK with it
2. If _users_ don't want to spend the time to update the SDK version they're using but still want to use a new feed, they have that option.

If we like this pattern, we should do the same for the `Market` enum.

The only downside to this is that the Java interaction becomes a bit more awkward, since Java usages must access the "enum" through the `.INSTANCE` member as shown in the updated Java sample. LMK what you think about this tradeoff.