### PR TITLE
Fix bug with missing message collector

### DIFF
--- a/src/main/kotlin/io/polygon/kotlin/sdk/Version.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/Version.kt
@@ -1,6 +1,6 @@
 package io.polygon.kotlin.sdk
 
 object Version {
-    const val name = "v5.1.1"
+    const val name = "v5.1.2"
     const val userAgent = "Polygon.io JVM Client/$name"
 }

--- a/src/main/kotlin/io/polygon/kotlin/sdk/websocket/PolygonWebSocketClient.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/websocket/PolygonWebSocketClient.kt
@@ -275,6 +275,7 @@ constructor(
                         Market.BusinessCrypto -> parseBusinessMessage(frame)
                         is Market.Other -> parseOtherMessage(frame)
                     }
+            collector.add(message)
         }
 
         return collector


### PR DESCRIPTION
Fixes https://github.com/polygon-io/client-jvm/issues/144. Added missing message collector for websocket event.

No messages were coming through when running the [KotlinStocksWebsocketSample.kt](https://github.com/polygon-io/client-jvm/blob/master/sample/src/main/java/io/polygon/kotlin/sdk/sample/KotlinStocksWebsocketSample.kt) via [KotlinUsageSample.kt](https://github.com/polygon-io/client-jvm/blob/master/sample/src/main/java/io/polygon/kotlin/sdk/sample/KotlinUsageSample.kt) when [stocksWebsocketSample(polygonKey)](https://github.com/polygon-io/client-jvm/blob/master/sample/src/main/java/io/polygon/kotlin/sdk/sample/KotlinUsageSample.kt#L89) was uncommented. After fixing this bug and rerunning you'll see events being passed correctly (like below).

```
...
Receieved Message: Trade(eventType=T, ticker=ACN, exchangeId=4, tradeId=71697218885707, tape=1, price=339.47, size=6.0, conditions=[37], timestampMillis=1704310583363, sequenceNumber=1338647, trf=202, trfTimestampMillis=1704310583363)
Receieved Message: Trade(eventType=T, ticker=LLY, exchangeId=4, tradeId=71697218885699, tape=1, price=617.97, size=1.0, conditions=[37], timestampMillis=1704310583349, sequenceNumber=1932601, trf=202, trfTimestampMillis=1704310583349)
Receieved Message: Trade(eventType=T, ticker=XOM, exchangeId=4, tradeId=71697218885199, tape=1, price=103.385, size=100.0, conditions=[], timestampMillis=1704310583254, sequenceNumber=2003481, trf=202, trfTimestampMillis=1704310583254)
...
```