### PR TITLE
Update Universal Snapshot 'session' model

### DIFF
--- a/.polygon/rest.json
+++ b/.polygon/rest.json
@@ -63,7 +63,7 @@
             },
             "AggregateTimeTo": {
                 "description": "The end of the aggregate time window. Either a date with the format YYYY-MM-DD or a millisecond timestamp.",
-                "example": "2023-01-09",
+                "example": "2023-02-10",
                 "in": "path",
                 "name": "to",
                 "required": true,
@@ -153,7 +153,7 @@
             },
             "IndicesAggregateTimeFrom": {
                 "description": "The start of the aggregate time window. Either a date with the format YYYY-MM-DD or a millisecond timestamp.",
-                "example": "2023-03-10",
+                "example": "2023-03-13",
                 "in": "path",
                 "name": "from",
                 "required": true,
@@ -163,7 +163,7 @@
             },
             "IndicesAggregateTimeTo": {
                 "description": "The end of the aggregate time window. Either a date with the format YYYY-MM-DD or a millisecond timestamp.",
-                "example": "2023-03-10",
+                "example": "2023-03-24",
                 "in": "path",
                 "name": "to",
                 "required": true,
@@ -13913,8 +13913,7 @@
                                                     "files_count",
                                                     "source_url",
                                                     "download_url",
-                                                    "entities",
-                                                    "acceptance_datetime"
+                                                    "entities"
                                                 ],
                                                 "type": "object",
                                                 "x-polygon-go-type": {
@@ -13986,121 +13985,125 @@
                                 },
                                 "schema": {
                                     "properties": {
-                                        "acceptance_datetime": {
-                                            "description": "The datetime when the filing was accepted by EDGAR in EST (format: YYYYMMDDHHMMSS)",
-                                            "type": "string"
-                                        },
-                                        "accession_number": {
-                                            "description": "Filing Accession Number",
-                                            "type": "string"
-                                        },
-                                        "entities": {
-                                            "description": "Entities related to the filing (e.g. the document filers).",
-                                            "items": {
-                                                "description": "A filing entity (e.g. the document filer).",
-                                                "properties": {
-                                                    "company_data": {
+                                        "results": {
+                                            "properties": {
+                                                "acceptance_datetime": {
+                                                    "description": "The datetime when the filing was accepted by EDGAR in EST (format: YYYYMMDDHHMMSS)",
+                                                    "type": "string"
+                                                },
+                                                "accession_number": {
+                                                    "description": "Filing Accession Number",
+                                                    "type": "string"
+                                                },
+                                                "entities": {
+                                                    "description": "Entities related to the filing (e.g. the document filers).",
+                                                    "items": {
+                                                        "description": "A filing entity (e.g. the document filer).",
                                                         "properties": {
-                                                            "cik": {
-                                                                "description": "Central Index Key (CIK) Number",
-                                                                "type": "string"
+                                                            "company_data": {
+                                                                "properties": {
+                                                                    "cik": {
+                                                                        "description": "Central Index Key (CIK) Number",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "name": {
+                                                                        "example": "Facebook Inc",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "sic": {
+                                                                        "description": "Standard Industrial Classification (SIC)",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "ticker": {
+                                                                        "description": "Ticker",
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "name",
+                                                                    "cik",
+                                                                    "sic"
+                                                                ],
+                                                                "type": "object",
+                                                                "x-polygon-go-type": {
+                                                                    "name": "SECCompanyData",
+                                                                    "path": "github.com/polygon-io/go-lib-models/v2/globals"
+                                                                }
                                                             },
-                                                            "name": {
-                                                                "example": "Facebook Inc",
-                                                                "type": "string"
-                                                            },
-                                                            "sic": {
-                                                                "description": "Standard Industrial Classification (SIC)",
-                                                                "type": "string"
-                                                            },
-                                                            "ticker": {
-                                                                "description": "Ticker",
+                                                            "relation": {
+                                                                "description": "Relationship of this entity to the filing.",
+                                                                "enum": [
+                                                                    "filer"
+                                                                ],
                                                                 "type": "string"
                                                             }
                                                         },
                                                         "required": [
-                                                            "name",
-                                                            "cik",
-                                                            "sic"
+                                                            "relation"
                                                         ],
                                                         "type": "object",
                                                         "x-polygon-go-type": {
-                                                            "name": "SECCompanyData",
+                                                            "name": "SECFilingEntity",
                                                             "path": "github.com/polygon-io/go-lib-models/v2/globals"
                                                         }
                                                     },
-                                                    "relation": {
-                                                        "description": "Relationship of this entity to the filing.",
-                                                        "enum": [
-                                                            "filer"
-                                                        ],
-                                                        "type": "string"
-                                                    }
+                                                    "type": "array"
                                                 },
-                                                "required": [
-                                                    "relation"
-                                                ],
-                                                "type": "object",
-                                                "x-polygon-go-type": {
-                                                    "name": "SECFilingEntity",
-                                                    "path": "github.com/polygon-io/go-lib-models/v2/globals"
+                                                "files_count": {
+                                                    "description": "The number of files associated with the filing.",
+                                                    "format": "int64",
+                                                    "type": "integer"
+                                                },
+                                                "filing_date": {
+                                                    "description": "The date when the filing was filed in YYYYMMDD format.",
+                                                    "example": "20210101",
+                                                    "pattern": "^[0-9]{8}$",
+                                                    "type": "string"
+                                                },
+                                                "id": {
+                                                    "description": "Unique identifier for the filing.",
+                                                    "type": "string"
+                                                },
+                                                "period_of_report_date": {
+                                                    "description": "The period of report for the filing in YYYYMMDD format.",
+                                                    "example": "20210101",
+                                                    "pattern": "^[0-9]{8}$",
+                                                    "type": "string"
+                                                },
+                                                "source_url": {
+                                                    "description": "The source URL is a link back to the upstream source for this filing\ndocument.",
+                                                    "example": "https://www.sec.gov/Archives/edgar/data/0001326801/000132680119000037/0001326801-19-000037-index.html",
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                },
+                                                "type": {
+                                                    "description": "Filing Type",
+                                                    "enum": [
+                                                        "10-K",
+                                                        "10-Q"
+                                                    ],
+                                                    "type": "string"
                                                 }
                                             },
-                                            "type": "array"
-                                        },
-                                        "files_count": {
-                                            "description": "The number of files associated with the filing.",
-                                            "format": "int64",
-                                            "type": "integer"
-                                        },
-                                        "filing_date": {
-                                            "description": "The date when the filing was filed in YYYYMMDD format.",
-                                            "example": "20210101",
-                                            "pattern": "^[0-9]{8}$",
-                                            "type": "string"
-                                        },
-                                        "id": {
-                                            "description": "Unique identifier for the filing.",
-                                            "type": "string"
-                                        },
-                                        "period_of_report_date": {
-                                            "description": "The period of report for the filing in YYYYMMDD format.",
-                                            "example": "20210101",
-                                            "pattern": "^[0-9]{8}$",
-                                            "type": "string"
-                                        },
-                                        "source_url": {
-                                            "description": "The source URL is a link back to the upstream source for this filing\ndocument.",
-                                            "example": "https://www.sec.gov/Archives/edgar/data/0001326801/000132680119000037/0001326801-19-000037-index.html",
-                                            "format": "uri",
-                                            "type": "string"
-                                        },
-                                        "type": {
-                                            "description": "Filing Type",
-                                            "enum": [
-                                                "10-K",
-                                                "10-Q"
+                                            "required": [
+                                                "id",
+                                                "accession_number",
+                                                "type",
+                                                "filing_date",
+                                                "period_of_report_date",
+                                                "files_count",
+                                                "source_url",
+                                                "download_url",
+                                                "entities"
                                             ],
-                                            "type": "string"
+                                            "type": "object",
+                                            "x-polygon-go-type": {
+                                                "name": "SECFiling",
+                                                "path": "github.com/polygon-io/go-lib-models/v2/globals"
+                                            }
                                         }
                                     },
-                                    "required": [
-                                        "id",
-                                        "accession_number",
-                                        "type",
-                                        "filing_date",
-                                        "period_of_report_date",
-                                        "files_count",
-                                        "source_url",
-                                        "download_url",
-                                        "entities",
-                                        "acceptance_datetime"
-                                    ],
-                                    "type": "object",
-                                    "x-polygon-go-type": {
-                                        "name": "SECFiling",
-                                        "path": "github.com/polygon-io/go-lib-models/v2/globals"
-                                    }
+                                    "type": "object"
                                 }
                             }
                         },
@@ -14493,6 +14496,114 @@
             },
             "x-polygon-draft": true
         },
+        "/v1/related-companies/{ticker}": {
+            "get": {
+                "description": "Get a list of tickers related to the queried ticker based on News and Returns data.",
+                "operationId": "GetRelatedCompanies",
+                "parameters": [
+                    {
+                        "description": "The ticker symbol to search.",
+                        "example": "AAPL",
+                        "in": "path",
+                        "name": "ticker",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "example": {
+                                    "request_id": "31d59dda-80e5-4721-8496-d0d32a654afe",
+                                    "results": [
+                                        {
+                                            "ticker": "MSFT"
+                                        },
+                                        {
+                                            "ticker": "GOOGL"
+                                        },
+                                        {
+                                            "ticker": "AMZN"
+                                        },
+                                        {
+                                            "ticker": "FB"
+                                        },
+                                        {
+                                            "ticker": "TSLA"
+                                        },
+                                        {
+                                            "ticker": "NVDA"
+                                        },
+                                        {
+                                            "ticker": "INTC"
+                                        },
+                                        {
+                                            "ticker": "ADBE"
+                                        },
+                                        {
+                                            "ticker": "NFLX"
+                                        },
+                                        {
+                                            "ticker": "PYPL"
+                                        }
+                                    ],
+                                    "status": "OK",
+                                    "stock_symbol": "AAPL"
+                                },
+                                "schema": {
+                                    "properties": {
+                                        "request_id": {
+                                            "description": "A request id assigned by the server.",
+                                            "type": "string"
+                                        },
+                                        "results": {
+                                            "items": {
+                                                "description": "The tickers related to the requested ticker.",
+                                                "properties": {
+                                                    "ticker": {
+                                                        "description": "A ticker related to the requested ticker.",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "ticker"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "status": {
+                                            "description": "The status of this request's response.",
+                                            "type": "string"
+                                        },
+                                        "ticker": {
+                                            "description": "The ticker being queried.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Related Companies."
+                    },
+                    "401": {
+                        "description": "Unauthorized - Check our API Key and account status"
+                    }
+                },
+                "summary": "Related Companies",
+                "tags": [
+                    "reference:related:companies"
+                ],
+                "x-polygon-entitlement-data-type": {
+                    "description": "Reference data",
+                    "name": "reference"
+                }
+            }
+        },
         "/v1/summaries": {
             "get": {
                 "description": "Get everything needed to visualize the tick-by-tick movement of a list of tickers.",
@@ -14539,7 +14650,7 @@
                                                 "volume": 37
                                             },
                                             "ticker": "NCLH",
-                                            "type": "stock"
+                                            "type": "stocks"
                                         },
                                         {
                                             "last_updated": 1679597116344223500,
@@ -14790,6 +14901,16 @@
                                                                 "format": "double",
                                                                 "type": "number"
                                                             },
+                                                            "regular_trading_change": {
+                                                                "description": "Today's change in regular trading hours, difference between current price and previous trading day's close, otherwise difference between today's close and previous day's close.",
+                                                                "format": "double",
+                                                                "type": "number"
+                                                            },
+                                                            "regular_trading_change_percent": {
+                                                                "description": "Today's regular trading change as a percentage.",
+                                                                "format": "double",
+                                                                "type": "number"
+                                                            },
                                                             "volume": {
                                                                 "description": "The trading volume for the asset for the day.",
                                                                 "format": "double",
@@ -14826,15 +14947,7 @@
                                                     }
                                                 },
                                                 "required": [
-                                                    "ticker",
-                                                    "name",
-                                                    "price",
-                                                    "branding",
-                                                    "market_status",
-                                                    "type",
-                                                    "session",
-                                                    "options",
-                                                    "last_updated"
+                                                    "ticker"
                                                 ],
                                                 "type": "object",
                                                 "x-polygon-go-type": {
@@ -15717,7 +15830,7 @@
                     },
                     {
                         "description": "The end of the aggregate time window. Either a date with the format YYYY-MM-DD or a millisecond timestamp.",
-                        "example": "2023-01-09",
+                        "example": "2023-02-10",
                         "in": "path",
                         "name": "to",
                         "required": true,
@@ -16170,7 +16283,7 @@
                     },
                     {
                         "description": "The end of the aggregate time window. Either a date with the format YYYY-MM-DD or a millisecond timestamp.",
-                        "example": "2023-01-09",
+                        "example": "2023-02-10",
                         "in": "path",
                         "name": "to",
                         "required": true,
@@ -16566,7 +16679,7 @@
                     },
                     {
                         "description": "The start of the aggregate time window. Either a date with the format YYYY-MM-DD or a millisecond timestamp.",
-                        "example": "2023-03-10",
+                        "example": "2023-03-13",
                         "in": "path",
                         "name": "from",
                         "required": true,
@@ -16576,7 +16689,7 @@
                     },
                     {
                         "description": "The end of the aggregate time window. Either a date with the format YYYY-MM-DD or a millisecond timestamp.",
-                        "example": "2023-03-10",
+                        "example": "2023-03-24",
                         "in": "path",
                         "name": "to",
                         "required": true,
@@ -16989,7 +17102,7 @@
                     },
                     {
                         "description": "The end of the aggregate time window. Either a date with the format YYYY-MM-DD or a millisecond timestamp.",
-                        "example": "2023-01-09",
+                        "example": "2023-02-10",
                         "in": "path",
                         "name": "to",
                         "required": true,
@@ -17437,7 +17550,7 @@
                     },
                     {
                         "description": "The end of the aggregate time window. Either a date with the format YYYY-MM-DD or a millisecond timestamp.",
-                        "example": "2023-01-09",
+                        "example": "2023-02-10",
                         "in": "path",
                         "name": "to",
                         "required": true,
@@ -18207,7 +18320,7 @@
                 "operationId": "ListNews",
                 "parameters": [
                     {
-                        "description": "Return results that contain this ticker.",
+                        "description": "Specify a case-sensitive ticker symbol. For example, AAPL represents Apple Inc.",
                         "in": "query",
                         "name": "ticker",
                         "schema": {
@@ -18391,52 +18504,35 @@
                                     "request_id": "831afdb0b8078549fed053476984947a",
                                     "results": [
                                         {
-                                            "amp_url": "https://amp.benzinga.com/amp/content/20784086",
-                                            "article_url": "https://www.benzinga.com/markets/cryptocurrency/21/04/20784086/cathie-wood-adds-more-coinbase-skillz-trims-square",
-                                            "author": "Rachit  Vats",
-                                            "description": "<p>Cathie Wood-led Ark Investment Management on Friday snapped up another 221,167 shares of the cryptocurrency exchange <strong>Coinbase Global Inc </strong>(NASDAQ <a class=\"ticker\" href=\"https://www.benzinga.com/stock/coin#NASDAQ\">COIN</a>) worth about $64.49 million on the stock&rsquo;s Friday&rsquo;s dip and also its fourth-straight loss.</p>\n<p>The investment firm&rsquo;s <strong>Ark Innovation ETF</strong> (NYSE <a class=\" ticker\" href=\"https://www.benzinga.com/stock/arkk#NYSE\">ARKK</a>) bought the shares of the company that closed 0.63% lower at $291.60 on Friday, giving the cryptocurrency exchange a market cap of $58.09 billion. Coinbase&rsquo;s market cap has dropped from $85.8 billion on its blockbuster listing earlier this month.</p>\n<p>The New York-based company also added another 3,873 shares of the mobile gaming company <strong>Skillz Inc</strong> (NYSE <a class=\" ticker\" href=\"https://www.benzinga.com/stock/sklz#NYSE\">SKLZ</a>), <a href=\"http://www.benzinga.com/markets/cryptocurrency/21/04/20762794/cathie-woods-ark-loads-up-another-1-2-million-shares-in-skillz-also-adds-coinbase-draftkin\" >just a day after</a> snapping 1.2 million shares of the stock.</p>\n <p>ARKK bought the shares of the company which closed ...</p><p><a href=https://www.benzinga.com/markets/cryptocurrency/21/04/20784086/cathie-wood-adds-more-coinbase-skillz-trims-square alt=Cathie Wood Adds More Coinbase, Skillz, Trims Square>Full story available on Benzinga.com</a></p>",
-                                            "id": "nJsSJJdwViHZcw5367rZi7_qkXLfMzacXBfpv-vD9UA",
-                                            "image_url": "https://cdn2.benzinga.com/files/imagecache/og_image_social_share_1200x630/images/story/2012/andre-francois-mckenzie-auhr4gcqcce-unsplash.jpg?width=720",
-                                            "keywords": [
-                                                "Sector ETFs",
-                                                "Penny Stocks",
-                                                "Cryptocurrency",
-                                                "Small Cap",
-                                                "Markets",
-                                                "Trading Ideas",
-                                                "ETFs"
+                                            "amp_url": "https://m.uk.investing.com/news/stock-market-news/markets-are-underestimating-fed-cuts-ubs-3559968?ampMode=1",
+                                            "article_url": "https://uk.investing.com/news/stock-market-news/markets-are-underestimating-fed-cuts-ubs-3559968",
+                                            "author": "Sam Boughedda",
+                                            "description": "UBS analysts warn that markets are underestimating the extent of future interest rate cuts by the Federal Reserve, as the weakening economy is likely to justify more cuts than currently anticipated.",
+                                            "id": "8ec638777ca03b553ae516761c2a22ba2fdd2f37befae3ab6fdab74e9e5193eb",
+                                            "image_url": "https://i-invdn-com.investing.com/news/LYNXNPEC4I0AL_L.jpg",
+                                            "insights": [
+                                                {
+                                                    "sentiment": "positive",
+                                                    "sentiment_reasoning": "UBS analysts are providing a bullish outlook on the extent of future Federal Reserve rate cuts, suggesting that markets are underestimating the number of cuts that will occur.",
+                                                    "ticker": "UBS"
+                                                }
                                             ],
-                                            "published_utc": "2021-04-26T02:33:17Z",
+                                            "keywords": [
+                                                "Federal Reserve",
+                                                "interest rates",
+                                                "economic data"
+                                            ],
+                                            "published_utc": "2024-06-24T18:33:53Z",
                                             "publisher": {
-                                                "favicon_url": "https://s3.polygon.io/public/public/assets/news/favicons/benzinga.ico",
-                                                "homepage_url": "https://www.benzinga.com/",
-                                                "logo_url": "https://s3.polygon.io/public/public/assets/news/logos/benzinga.svg",
-                                                "name": "Benzinga"
+                                                "favicon_url": "https://s3.polygon.io/public/assets/news/favicons/investing.ico",
+                                                "homepage_url": "https://www.investing.com/",
+                                                "logo_url": "https://s3.polygon.io/public/assets/news/logos/investing.png",
+                                                "name": "Investing.com"
                                             },
                                             "tickers": [
-                                                "DOCU",
-                                                "DDD",
-                                                "NIU",
-                                                "ARKF",
-                                                "NVDA",
-                                                "SKLZ",
-                                                "PCAR",
-                                                "MASS",
-                                                "PSTI",
-                                                "SPFR",
-                                                "TREE",
-                                                "PHR",
-                                                "IRDM",
-                                                "BEAM",
-                                                "ARKW",
-                                                "ARKK",
-                                                "ARKG",
-                                                "PSTG",
-                                                "SQ",
-                                                "IONS",
-                                                "SYRS"
+                                                "UBS"
                                             ],
-                                            "title": "Cathie Wood Adds More Coinbase, Skillz, Trims Square"
+                                            "title": "Markets are underestimating Fed cuts: UBS By Investing.com - Investing.com UK"
                                         }
                                     ],
                                     "status": "OK"
@@ -18481,6 +18577,37 @@
                                                     "image_url": {
                                                         "description": "The article's image URL.",
                                                         "type": "string"
+                                                    },
+                                                    "insights": {
+                                                        "description": "The insights related to the article.",
+                                                        "items": {
+                                                            "properties": {
+                                                                "sentiment": {
+                                                                    "description": "The sentiment of the insight.",
+                                                                    "enum": [
+                                                                        "positive",
+                                                                        "neutral",
+                                                                        "negative"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                "sentiment_reasoning": {
+                                                                    "description": "The reasoning behind the sentiment.",
+                                                                    "type": "string"
+                                                                },
+                                                                "ticker": {
+                                                                    "description": "The ticker symbol associated with the insight.",
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "ticker",
+                                                                "sentiment",
+                                                                "sentiment_reasoning"
+                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array"
                                                     },
                                                     "keywords": {
                                                         "description": "The keywords associated with the article (which will vary depending on\nthe publishing source).",
@@ -18562,7 +18689,7 @@
                                 }
                             },
                             "text/csv": {
-                                "example": "id,publisher_name,publisher_homepage_url,publisher_logo_url,publisher_favicon_url,title,author,published_utc,article_url,tickers,amp_url,image_url,description,keywords\nnJsSJJdwViHZcw5367rZi7_qkXLfMzacXBfpv-vD9UA,Benzinga,https://www.benzinga.com/,https://s3.polygon.io/public/public/assets/news/logos/benzinga.svg,https://s3.polygon.io/public/public/assets/news/favicons/benzinga.ico,\"Cathie Wood Adds More Coinbase, Skillz, Trims Square\",Rachit  Vats,2021-04-26T02:33:17Z,https://www.benzinga.com/markets/cryptocurrency/21/04/20784086/cathie-wood-adds-more-coinbase-skillz-trims-square,\"DOCU,DDD,NIU,ARKF,NVDA,SKLZ,PCAR,MASS,PSTI,SPFR,TREE,PHR,IRDM,BEAM,ARKW,ARKK,ARKG,PSTG,SQ,IONS,SYRS\",https://amp.benzinga.com/amp/content/20784086,https://cdn2.benzinga.com/files/imagecache/og_image_social_share_1200x630/images/story/2012/andre-francois-mckenzie-auhr4gcqcce-unsplash.jpg?width=720,\"<p>Cathie Wood-led Ark Investment Management on Friday snapped up another 221,167 shares of the cryptocurrency exchange <strong>Coinbase Global Inc </strong>(NASDAQ <a class=\\\"ticker\\\" href=\\\"https://www.benzinga.com/stock/coin#NASDAQ\\\">COIN</a>) worth about $64.49 million on the stock&rsquo;s Friday&rsquo;s dip and also its fourth-straight loss.</p> <p>The investment firm&rsquo;s <strong>Ark Innovation ETF</strong> (NYSE <a class=\\\" ticker\\\" href=\\\"https://www.benzinga.com/stock/arkk#NYSE\\\">ARKK</a>) bought the shares of the company that closed 0.63% lower at $291.60 on Friday, giving the cryptocurrency exchange a market cap of $58.09 billion. Coinbase&rsquo;s market cap has dropped from $85.8 billion on its blockbuster listing earlier this month.</p> <p>The New York-based company also added another 3,873 shares of the mobile gaming company <strong>Skillz Inc</strong> (NYSE <a class=\\\" ticker\\\" href=\\\"https://www.benzinga.com/stock/sklz#NYSE\\\">SKLZ</a>), <a href=\\\"http://www.benzinga.com/markets/cryptocurrency/21/04/20762794/cathie-woods-ark-loads-up-another-1-2-million-shares-in-skillz-also-adds-coinbase-draftkin\\\" >just a day after</a> snapping 1.2 million shares of the stock.</p> <p>ARKK bought the shares of the company which closed ...</p><p><a href=https://www.benzinga.com/markets/cryptocurrency/21/04/20784086/cathie-wood-adds-more-coinbase-skillz-trims-square alt=Cathie Wood Adds More Coinbase, Skillz, Trims Square>Full story available on Benzinga.com</a></p>\",\"Sector ETFs,Penny Stocks,Cryptocurrency,Small Cap,Markets,Trading Ideas,ETFs\"\n",
+                                "example": "id,publisher_name,publisher_homepage_url,publisher_logo_url,publisher_favicon_url,title,author,published_utc,article_url,ticker,amp_url,image_url,description,keywords,sentiment,sentiment_reasoning\n8ec638777ca03b553ae516761c2a22ba2fdd2f37befae3ab6fdab74e9e5193eb,Investing.com,https://www.investing.com/,https://s3.polygon.io/public/assets/news/logos/investing.png,https://s3.polygon.io/public/assets/news/favicons/investing.ico,Markets are underestimating Fed cuts: UBS By Investing.com - Investing.com UK,Sam Boughedda,1719254033000000000,https://uk.investing.com/news/stock-market-news/markets-are-underestimating-fed-cuts-ubs-3559968,UBS,https://m.uk.investing.com/news/stock-market-news/markets-are-underestimating-fed-cuts-ubs-3559968?ampMode=1,https://i-invdn-com.investing.com/news/LYNXNPEC4I0AL_L.jpg,\"UBS analysts warn that markets are underestimating the extent of future interest rate cuts by the Federal Reserve, as the weakening economy is likely to justify more cuts than currently anticipated.\",\"Federal Reserve,interest rates,economic data\",positive,\"UBS analysts are providing a bullish outlook on the extent of future Federal Reserve rate cuts, suggesting that markets are underestimating the number of cuts that will occur.\"\n",
                                 "schema": {
                                     "type": "string"
                                 }
@@ -22759,11 +22886,11 @@
                         }
                     },
                     {
-                        "description": "Limit the number of results returned, default is 10 and max is 50000.",
+                        "description": "Limit the number of results returned, default is 1000 and max is 50000.",
                         "in": "query",
                         "name": "limit",
                         "schema": {
-                            "default": 10,
+                            "default": 1000,
                             "example": 10,
                             "maximum": 50000,
                             "minimum": 1,
@@ -22888,6 +23015,8 @@
                 },
                 "x-polygon-paginate": {
                     "limit": {
+                        "default": 1000,
+                        "example": 10,
                         "max": 50000
                     },
                     "order": {
@@ -22984,11 +23113,11 @@
                         }
                     },
                     {
-                        "description": "Limit the number of results returned, default is 10 and max is 50000.",
+                        "description": "Limit the number of results returned, default is 1000 and max is 50000.",
                         "in": "query",
                         "name": "limit",
                         "schema": {
-                            "default": 10,
+                            "default": 1000,
                             "example": 10,
                             "maximum": 50000,
                             "minimum": 1,
@@ -23135,6 +23264,8 @@
                 },
                 "x-polygon-paginate": {
                     "limit": {
+                        "default": 1000,
+                        "example": 10,
                         "max": 50000
                     },
                     "order": {
@@ -23224,11 +23355,11 @@
                         }
                     },
                     {
-                        "description": "Limit the number of results returned, default is 10 and max is 50000.",
+                        "description": "Limit the number of results returned, default is 1000 and max is 50000.",
                         "in": "query",
                         "name": "limit",
                         "schema": {
-                            "default": 10,
+                            "default": 1000,
                             "example": 10,
                             "maximum": 50000,
                             "minimum": 1,
@@ -23436,6 +23567,8 @@
                 },
                 "x-polygon-paginate": {
                     "limit": {
+                        "default": 1000,
+                        "example": 10,
                         "max": 50000
                     },
                     "order": {
@@ -24208,7 +24341,7 @@
                 "operationId": "ListDividends",
                 "parameters": [
                     {
-                        "description": "Return the dividends that contain this ticker.",
+                        "description": "Specify a case-sensitive ticker symbol. For example, AAPL represents Apple Inc.",
                         "in": "query",
                         "name": "ticker",
                         "schema": {
@@ -24588,6 +24721,7 @@
                                                 "dividend_type": "CD",
                                                 "ex_dividend_date": "2021-11-05",
                                                 "frequency": 4,
+                                                "id": "E8e3c4f794613e9205e2f178a36c53fcc57cdabb55e1988c87b33f9e52e221444",
                                                 "pay_date": "2021-11-11",
                                                 "record_date": "2021-11-08",
                                                 "ticker": "AAPL"
@@ -24598,6 +24732,7 @@
                                                 "dividend_type": "CD",
                                                 "ex_dividend_date": "2021-08-06",
                                                 "frequency": 4,
+                                                "id": "E6436c5475706773f03490acf0b63fdb90b2c72bfeed329a6eb4afc080acd80ae",
                                                 "pay_date": "2021-08-12",
                                                 "record_date": "2021-08-09",
                                                 "ticker": "AAPL"
@@ -24686,6 +24821,10 @@
                                                             ]
                                                         }
                                                     },
+                                                    "id": {
+                                                        "description": "The unique identifier of the dividend.",
+                                                        "type": "string"
+                                                    },
                                                     "pay_date": {
                                                         "description": "The date that the dividend is paid out.",
                                                         "type": "string"
@@ -24712,7 +24851,8 @@
                                                     "ex_dividend_date",
                                                     "frequency",
                                                     "cash_amount",
-                                                    "dividend_type"
+                                                    "dividend_type",
+                                                    "id"
                                                 ],
                                                 "type": "object",
                                                 "x-polygon-go-struct-tags": {
@@ -25401,7 +25541,7 @@
                 "parameters": [
                     {
                         "description": "Query for a contract by options ticker. You can learn more about the structure of options tickers [here](https://polygon.io/blog/how-to-read-a-stock-options-ticker/).",
-                        "example": "O:EVRI240119C00002500",
+                        "example": "O:SPY251219C00650000",
                         "in": "path",
                         "name": "options_ticker",
                         "required": true,
@@ -25721,12 +25861,14 @@
                                     "results": [
                                         {
                                             "execution_date": "2020-08-31",
+                                            "id": "E36416cce743c3964c5da63e1ef1626c0aece30fb47302eea5a49c0055c04e8d0",
                                             "split_from": 1,
                                             "split_to": 4,
                                             "ticker": "AAPL"
                                         },
                                         {
                                             "execution_date": "2005-02-28",
+                                            "id": "E90a77bdf742661741ed7c8fc086415f0457c2816c45899d73aaa88bdc8ff6025",
                                             "split_from": 1,
                                             "split_to": 2,
                                             "ticker": "AAPL"
@@ -25750,6 +25892,10 @@
                                                         "description": "The execution date of the stock split. On this date the stock split was applied.",
                                                         "type": "string"
                                                     },
+                                                    "id": {
+                                                        "description": "The unique identifier for this stock split.",
+                                                        "type": "string"
+                                                    },
                                                     "split_from": {
                                                         "description": "The second number in the split ratio.\n\nFor example: In a 2-for-1 split, split_from would be 1.",
                                                         "format": "float",
@@ -25767,7 +25913,10 @@
                                                 },
                                                 "required": [
                                                     "split_from",
-                                                    "split_to"
+                                                    "split_to",
+                                                    "id",
+                                                    "ticker",
+                                                    "execution_date"
                                                 ],
                                                 "type": "object"
                                             },
@@ -27077,8 +27226,6 @@
                                                             }
                                                         },
                                                         "required": [
-                                                            "last_updated",
-                                                            "timeframe",
                                                             "ask",
                                                             "bid",
                                                             "last_updated",
@@ -27152,9 +27299,6 @@
                                                             }
                                                         },
                                                         "required": [
-                                                            "last_updated",
-                                                            "timeframe",
-                                                            "participant_timestamp",
                                                             "price",
                                                             "size"
                                                         ],
@@ -27242,6 +27386,16 @@
                                                                 "format": "double",
                                                                 "type": "number"
                                                             },
+                                                            "regular_trading_change": {
+                                                                "description": "Today's change in regular trading hours, difference between current price and previous trading day's close, otherwise difference between today's close and previous day's close.",
+                                                                "format": "double",
+                                                                "type": "number"
+                                                            },
+                                                            "regular_trading_change_percent": {
+                                                                "description": "Today's regular trading change as a percentage.",
+                                                                "format": "double",
+                                                                "type": "number"
+                                                            },
                                                             "volume": {
                                                                 "description": "The trading volume for the asset for the day.",
                                                                 "format": "double",
@@ -27318,8 +27472,6 @@
                                                             }
                                                         },
                                                         "required": [
-                                                            "last_updated",
-                                                            "timeframe",
                                                             "ticker",
                                                             "change_to_break_even"
                                                         ],
@@ -27633,9 +27785,7 @@
                                                     }
                                                 },
                                                 "required": [
-                                                    "ticker",
-                                                    "timeframe",
-                                                    "last_updated"
+                                                    "ticker"
                                                 ],
                                                 "type": "object",
                                                 "x-polygon-go-type": {
@@ -27894,7 +28044,8 @@
                                                 "bid": 120.28,
                                                 "bid_size": 8,
                                                 "last_updated": 1605195918507251700,
-                                                "midpoint": 120.29
+                                                "midpoint": 120.29,
+                                                "timeframe": "REAL-TIME"
                                             },
                                             "last_trade": {
                                                 "conditions": [
@@ -27995,7 +28146,6 @@
                                                             }
                                                         },
                                                         "required": [
-                                                            "last_updated",
                                                             "open",
                                                             "high",
                                                             "low",
@@ -28169,8 +28319,6 @@
                                                             }
                                                         },
                                                         "required": [
-                                                            "last_updated",
-                                                            "timeframe",
                                                             "ask",
                                                             "ask_size",
                                                             "bid_size",
@@ -28223,7 +28371,6 @@
                                                             }
                                                         },
                                                         "required": [
-                                                            "timeframe",
                                                             "exchange",
                                                             "price",
                                                             "sip_timestamp",
@@ -28280,8 +28427,6 @@
                                                             }
                                                         },
                                                         "required": [
-                                                            "last_updated",
-                                                            "timeframe",
                                                             "ticker",
                                                             "change_to_break_even"
                                                         ],
@@ -28296,7 +28441,6 @@
                                                     "last_quote",
                                                     "underlying_asset",
                                                     "details",
-                                                    "cha",
                                                     "break_even_price",
                                                     "open_interest"
                                                 ],
@@ -28531,7 +28675,6 @@
                                                         }
                                                     },
                                                     "required": [
-                                                        "last_updated",
                                                         "open",
                                                         "high",
                                                         "low",
@@ -28705,8 +28848,6 @@
                                                         }
                                                     },
                                                     "required": [
-                                                        "last_updated",
-                                                        "timeframe",
                                                         "ask",
                                                         "ask_size",
                                                         "bid_size",
@@ -28759,7 +28900,6 @@
                                                         }
                                                     },
                                                     "required": [
-                                                        "timeframe",
                                                         "exchange",
                                                         "price",
                                                         "sip_timestamp",
@@ -28816,8 +28956,6 @@
                                                         }
                                                     },
                                                     "required": [
-                                                        "last_updated",
-                                                        "timeframe",
                                                         "ticker",
                                                         "change_to_break_even"
                                                     ],
@@ -28832,7 +28970,6 @@
                                                 "last_quote",
                                                 "underlying_asset",
                                                 "details",
-                                                "cha",
                                                 "break_even_price",
                                                 "open_interest"
                                             ],
@@ -28960,11 +29097,11 @@
                         }
                     },
                     {
-                        "description": "Limit the number of results returned, default is 10 and max is 50000.",
+                        "description": "Limit the number of results returned, default is 1000 and max is 50000.",
                         "in": "query",
                         "name": "limit",
                         "schema": {
-                            "default": 10,
+                            "default": 1000,
                             "example": 10,
                             "maximum": 50000,
                             "minimum": 1,
@@ -29110,6 +29247,8 @@
                 },
                 "x-polygon-paginate": {
                     "limit": {
+                        "default": 1000,
+                        "example": 10,
                         "max": 50000
                     },
                     "order": {
@@ -29206,11 +29345,11 @@
                         }
                     },
                     {
-                        "description": "Limit the number of results returned, default is 10 and max is 50000.",
+                        "description": "Limit the number of results returned, default is 1000 and max is 50000.",
                         "in": "query",
                         "name": "limit",
                         "schema": {
-                            "default": 10,
+                            "default": 1000,
                             "example": 10,
                             "maximum": 50000,
                             "minimum": 1,
@@ -29362,6 +29501,8 @@
                 },
                 "x-polygon-paginate": {
                     "limit": {
+                        "default": 1000,
+                        "example": 10,
                         "max": 50000
                     },
                     "order": {
@@ -29451,11 +29592,11 @@
                         }
                     },
                     {
-                        "description": "Limit the number of results returned, default is 10 and max is 50000.",
+                        "description": "Limit the number of results returned, default is 1000 and max is 50000.",
                         "in": "query",
                         "name": "limit",
                         "schema": {
-                            "default": 10,
+                            "default": 1000,
                             "example": 10,
                             "maximum": 50000,
                             "minimum": 1,
@@ -29651,6 +29792,8 @@
                 },
                 "x-polygon-paginate": {
                     "limit": {
+                        "default": 1000,
+                        "example": 10,
                         "max": 50000
                     },
                     "order": {
@@ -30357,6 +30500,386 @@
                         "enum": [
                             "filing_date",
                             "period_of_report_date"
+                        ]
+                    }
+                }
+            }
+        },
+        "/vX/reference/ipos": {
+            "get": {
+                "description": "The IPOs API provides access to detailed information about Initial Public Offerings (IPOs), including both upcoming and historical events. With this API, you can query for a comprehensive list of IPOs, along with key details such as the issuer name, ticker symbol, ISIN, IPO date, number of shares offered, expected price range, and final offering price. You can filter the results by status to focus on new, rumors, pending, historical, and more.",
+                "operationId": "ListIPOs",
+                "parameters": [
+                    {
+                        "description": "Specify a case-sensitive ticker symbol. For example, AAPL represents Apple Inc.",
+                        "in": "query",
+                        "name": "ticker",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Specify a us_code. This is a unique nine-character alphanumeric code that identifies a North American financial security for the purposes of facilitating clearing and settlement of trades.",
+                        "in": "query",
+                        "name": "us_code",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Specify an International Securities Identification Number (ISIN). This is a unique twelve-digit code that is assigned to every security issuance in the world.",
+                        "in": "query",
+                        "name": "isin",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Specify a listing date. This is the first trading date for the newly listed entity.",
+                        "in": "query",
+                        "name": "listing_date",
+                        "schema": {
+                            "format": "date",
+                            "type": "string"
+                        },
+                        "x-polygon-filter-field": {
+                            "range": true,
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Specify an IPO status.",
+                        "in": "query",
+                        "name": "ipo_status",
+                        "schema": {
+                            "enum": [
+                                "direct_listing_process",
+                                "history",
+                                "new",
+                                "pending",
+                                "postponed",
+                                "rumor",
+                                "withdrawn"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Range by listing_date.",
+                        "in": "query",
+                        "name": "listing_date.gte",
+                        "schema": {
+                            "format": "date",
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Range by listing_date.",
+                        "in": "query",
+                        "name": "listing_date.gt",
+                        "schema": {
+                            "format": "date",
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Range by listing_date.",
+                        "in": "query",
+                        "name": "listing_date.lte",
+                        "schema": {
+                            "format": "date",
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Range by listing_date.",
+                        "in": "query",
+                        "name": "listing_date.lt",
+                        "schema": {
+                            "format": "date",
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Order results based on the `sort` field.",
+                        "in": "query",
+                        "name": "order",
+                        "schema": {
+                            "default": "desc",
+                            "enum": [
+                                "asc",
+                                "desc"
+                            ],
+                            "example": "asc",
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Limit the number of results returned, default is 10 and max is 1000.",
+                        "in": "query",
+                        "name": "limit",
+                        "schema": {
+                            "default": 10,
+                            "example": 10,
+                            "maximum": 1000,
+                            "minimum": 1,
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Sort field used for ordering.",
+                        "in": "query",
+                        "name": "sort",
+                        "schema": {
+                            "default": "listing_date",
+                            "enum": [
+                                "listing_date",
+                                "ticker",
+                                "last_updated",
+                                "security_type",
+                                "issuer_name",
+                                "currency_code",
+                                "isin",
+                                "us_code",
+                                "final_issue_price",
+                                "min_shares_offered",
+                                "max_shares_offered",
+                                "lowest_offer_price",
+                                "highest_offer_price",
+                                "total_offer_size",
+                                "shares_outstanding",
+                                "primary_exchange",
+                                "lot_size",
+                                "security_description",
+                                "ipo_status"
+                            ],
+                            "example": "listing_date",
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "example": {
+                                    "next_url": "https://api.polygon.io/vX/reference/ipos?cursor=YWN0aXZlPXRydWUmZGF0ZT0yMDIxLTA0LTI1JmxpbWl0PTEmb3JkZXI9YXNjJnBhZ2VfbWFya2VyPUElN0M5YWRjMjY0ZTgyM2E1ZjBiOGUyNDc5YmZiOGE1YmYwNDVkYzU0YjgwMDcyMWE2YmI1ZjBjMjQwMjU4MjFmNGZiJnNvcnQ9dGlja2Vy",
+                                    "request_id": "6a7e466379af0a71039d60cc78e72282",
+                                    "results": [
+                                        {
+                                            "currency_code": "USD",
+                                            "final_issue_price": 17,
+                                            "highest_offer_price": 17,
+                                            "ipo_status": "history",
+                                            "isin": "US75383L1026",
+                                            "issue_end_date": "2024-06-06",
+                                            "issue_start_date": "2024-06-01",
+                                            "issuer_name": "Rapport Therapeutics Inc.",
+                                            "last_updated": "2024-06-27",
+                                            "listing_date": "2024-06-07",
+                                            "lot_size": 100,
+                                            "lowest_offer_price": 17,
+                                            "max_shares_offered": 8000000,
+                                            "min_shares_offered": 1000000,
+                                            "primary_exchange": "XNAS",
+                                            "security_description": "Ordinary Shares",
+                                            "security_type": "CS",
+                                            "shares_outstanding": 35376457,
+                                            "ticker": "RAPP",
+                                            "total_offer_size": 136000000,
+                                            "us_code": "75383L102"
+                                        }
+                                    ],
+                                    "status": "OK"
+                                },
+                                "schema": {
+                                    "properties": {
+                                        "next_url": {
+                                            "description": "If present, this value can be used to fetch the next page of data.",
+                                            "type": "string"
+                                        },
+                                        "request_id": {
+                                            "type": "string"
+                                        },
+                                        "results": {
+                                            "items": {
+                                                "properties": {
+                                                    "currency_code": {
+                                                        "description": "Underlying currency of the security.",
+                                                        "example": "USD",
+                                                        "type": "string"
+                                                    },
+                                                    "final_issue_price": {
+                                                        "description": "The price set by the company and its underwriters before the IPO goes live.",
+                                                        "example": 14.5,
+                                                        "format": "float",
+                                                        "type": "number"
+                                                    },
+                                                    "highest_offer_price": {
+                                                        "description": "The highest price within the IPO price range that the company might use to price the shares.",
+                                                        "example": 20,
+                                                        "format": "float",
+                                                        "type": "number"
+                                                    },
+                                                    "ipo_status": {
+                                                        "description": "The status of the IPO event.",
+                                                        "enum": [
+                                                            "direct_listing_process",
+                                                            "history",
+                                                            "new",
+                                                            "pending",
+                                                            "postponed",
+                                                            "rumor",
+                                                            "withdrawn"
+                                                        ],
+                                                        "example": "history",
+                                                        "type": "string"
+                                                    },
+                                                    "isin": {
+                                                        "description": "International Securities Identification Number. This is a unique twelve-digit code that is assigned to every security issuance in the world.",
+                                                        "example": "US0378331005",
+                                                        "type": "string"
+                                                    },
+                                                    "issuer_name": {
+                                                        "description": "Name of issuer.",
+                                                        "example": "Apple Inc.",
+                                                        "type": "string"
+                                                    },
+                                                    "last_updated": {
+                                                        "description": "The date when the IPO event was last modified.",
+                                                        "example": "2023-01-02",
+                                                        "format": "date",
+                                                        "type": "string"
+                                                    },
+                                                    "listing_date": {
+                                                        "description": "First trading date for the newly listed entity.",
+                                                        "example": "2023-02-01",
+                                                        "format": "date",
+                                                        "type": "string"
+                                                    },
+                                                    "lot_size": {
+                                                        "description": "The minimum number of shares that can be bought or sold in a single transaction.",
+                                                        "example": 100,
+                                                        "type": "number"
+                                                    },
+                                                    "lowest_offer_price": {
+                                                        "description": "The lowest price within the IPO price range that the company is willing to offer its shares to investors.",
+                                                        "example": 10,
+                                                        "format": "float",
+                                                        "type": "number"
+                                                    },
+                                                    "max_shares_offered": {
+                                                        "description": "The upper limit of the shares that the company is offering to investors.",
+                                                        "example": 1000,
+                                                        "type": "number"
+                                                    },
+                                                    "min_shares_offered": {
+                                                        "description": "The lower limit of shares that the company is willing to sell in the IPO.",
+                                                        "example": 1000,
+                                                        "type": "number"
+                                                    },
+                                                    "primary_exchange": {
+                                                        "description": "Market Identifier Code (MIC) of the primary exchange where the security is listed. The Market Identifier Code (MIC) (ISO 10383) is a unique identification code used to identify securities trading exchanges, regulated and non-regulated trading markets.",
+                                                        "example": "XNAS",
+                                                        "type": "string"
+                                                    },
+                                                    "security_description": {
+                                                        "description": "Description of the security.",
+                                                        "example": "Ordinary Shares - Class A",
+                                                        "type": "string"
+                                                    },
+                                                    "security_type": {
+                                                        "description": "The classification of the stock. For example, \"CS\" stands for Common Stock.",
+                                                        "example": "CS",
+                                                        "type": "string"
+                                                    },
+                                                    "shares_outstanding": {
+                                                        "description": "The total number of shares that the company has issued and are held by investors.",
+                                                        "example": 1000000,
+                                                        "type": "number"
+                                                    },
+                                                    "ticker": {
+                                                        "description": "The ticker symbol of the IPO event.",
+                                                        "example": "AAPL",
+                                                        "type": "string"
+                                                    },
+                                                    "total_offer_size": {
+                                                        "description": "The total amount raised by the company for IPO.",
+                                                        "example": 1000000,
+                                                        "format": "float",
+                                                        "type": "number"
+                                                    },
+                                                    "us_code": {
+                                                        "description": "This is a unique nine-character alphanumeric code that identifies a North American financial security for the purposes of facilitating clearing and settlement of trades.",
+                                                        "example": 37833100,
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "last_updated",
+                                                    "primary_exchange",
+                                                    "security_type",
+                                                    "security_description",
+                                                    "ipo_status"
+                                                ],
+                                                "type": "object",
+                                                "x-polygon-go-type": {
+                                                    "name": "IPOsResult"
+                                                }
+                                            },
+                                            "type": "array"
+                                        },
+                                        "status": {
+                                            "description": "The status of this request's response.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "A list of IPO events."
+                    }
+                },
+                "summary": "IPOs",
+                "tags": [
+                    "reference:stocks:ipos"
+                ],
+                "x-polygon-entitlement-data-type": {
+                    "description": "Reference data",
+                    "name": "reference"
+                },
+                "x-polygon-paginate": {
+                    "limit": {
+                        "default": 10,
+                        "max": 1000
+                    },
+                    "order": {
+                        "default": "desc"
+                    },
+                    "sort": {
+                        "default": "listing_date",
+                        "enum": [
+                            "listing_date",
+                            "ticker",
+                            "last_updated",
+                            "security_type",
+                            "issuer_name",
+                            "currency_code",
+                            "isin",
+                            "us_code",
+                            "final_issue_price",
+                            "min_shares_offered",
+                            "max_shares_offered",
+                            "lowest_offer_price",
+                            "highest_offer_price",
+                            "total_offer_size",
+                            "shares_outstanding",
+                            "primary_exchange",
+                            "lot_size",
+                            "security_description",
+                            "ipo_status"
                         ]
                     }
                 }
@@ -31297,6 +31820,21 @@
                 {
                     "paths": [
                         "/v3/reference/exchanges"
+                    ]
+                },
+                {
+                    "paths": [
+                        "/v1/related-companies/{ticker}"
+                    ]
+                },
+                {
+                    "paths": [
+                        "/vX/reference/ipos"
+                    ]
+                },
+                {
+                    "paths": [
+                        "/vX/reference/short-interest/{identifier_type}/{identifier}"
                     ]
                 }
             ]

--- a/.polygon/websocket.json
+++ b/.polygon/websocket.json
@@ -269,7 +269,7 @@
                                         },
                                         "c": {
                                             "type": "array",
-                                            "description": "The trade conditions. See <a target=\"_blank\" href=\"https://polygon.io/glossary/us/stocks/conditions-indicators\" \nalt=\"Conditions and Indicators\">Conditions and Indicators\"</a> for Polygon.io's trade conditions glossary.\n",
+                                            "description": "The trade conditions. See <a target=\"_blank\" href=\"https://polygon.io/glossary/us/stocks/conditions-indicators\" \nalt=\"Conditions and Indicators\">Conditions and Indicators</a> for Polygon.io's trade conditions glossary.\n",
                                             "items": {
                                                 "type": "integer",
                                                 "description": "The ID of the condition."
@@ -277,7 +277,7 @@
                                         },
                                         "t": {
                                             "type": "integer",
-                                            "description": "The Timestamp in Unix MS."
+                                            "description": "The SIP timestamp in Unix MS."
                                         },
                                         "q": {
                                             "type": "integer",
@@ -407,7 +407,7 @@
                                         },
                                         "t": {
                                             "type": "integer",
-                                            "description": "The Timestamp in Unix MS."
+                                            "description": "The SIP timestamp in Unix MS."
                                         },
                                         "q": {
                                             "type": "integer",
@@ -3964,7 +3964,7 @@
                     },
                     "c": {
                         "type": "array",
-                        "description": "The trade conditions. See <a target=\"_blank\" href=\"https://polygon.io/glossary/us/stocks/conditions-indicators\" \nalt=\"Conditions and Indicators\">Conditions and Indicators\"</a> for Polygon.io's trade conditions glossary.\n",
+                        "description": "The trade conditions. See <a target=\"_blank\" href=\"https://polygon.io/glossary/us/stocks/conditions-indicators\" \nalt=\"Conditions and Indicators\">Conditions and Indicators</a> for Polygon.io's trade conditions glossary.\n",
                         "items": {
                             "type": "integer",
                             "description": "The ID of the condition."
@@ -3972,7 +3972,7 @@
                     },
                     "t": {
                         "type": "integer",
-                        "description": "The Timestamp in Unix MS."
+                        "description": "The SIP timestamp in Unix MS."
                     },
                     "q": {
                         "type": "integer",
@@ -4041,7 +4041,7 @@
                     },
                     "t": {
                         "type": "integer",
-                        "description": "The Timestamp in Unix MS."
+                        "description": "The SIP timestamp in Unix MS."
                     },
                     "q": {
                         "type": "integer",

--- a/src/main/kotlin/io/polygon/kotlin/sdk/Version.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/Version.kt
@@ -1,6 +1,6 @@
 package io.polygon.kotlin.sdk
 
 object Version {
-    const val name = "v5.1.2"
+    const val name = "v5.1.3"
     const val userAgent = "Polygon.io JVM Client/$name"
 }

--- a/src/main/kotlin/io/polygon/kotlin/sdk/rest/Snapshots.kt
+++ b/src/main/kotlin/io/polygon/kotlin/sdk/rest/Snapshots.kt
@@ -60,11 +60,12 @@ data class SnapshotsResponse(
 
 @Serializable
 data class Snapshot (
-    // Common: fields that apply to most/all of the asset types.
+    // Common: fields that apply to most/all the asset types.
     val error: String? = null,
     val message: String? = null,
     val market_status: String? = null,
     val name: String? = null,
+    val ticker: String? = null,
     val type: String? = null, // Type of the asset: stocks, options, fx, crypto, indices.
     @SerialName("session") val session: SnapshotSession? = null,
 
@@ -96,6 +97,8 @@ data class SnapshotSession(
     @SerialName("close") val close: Double? = null,
     @SerialName("early_trading_change") val earlyTradingChange: Double? = null,
     @SerialName("early_trading_change_percent") val earlyTradingChangePercent: Double? = null,
+    @SerialName("regular_trading_change") val regularTradingChange: Double? = null,
+    @SerialName("regular_trading_change_percent") val regularTradingChangePercent: Double? = null,
     @SerialName("high") val high: Double? = null,
     @SerialName("late_trading_change") val lateTradingChange: Double? = null,
     @SerialName("late_trading_change_percent") val lateTradingChangePercent: Double? = null,


### PR DESCRIPTION
We recently added `regular_trading_change` and `regular_trading_change_percent` to this response, which represents the change in the asset between its open and close.

Universal Snapshot response was also missing the `ticker` field (closes #150) so added that.