### PR TITLE
[DEVREL-139] Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @justinpolygon @suever @kschoche @lukeoleson @mmoghaddam385 @jbonzo


### PR DESCRIPTION
Updates `.github/CODEOWNERS` to the standard DevRel team format:

```
* @justinpolygon @suever @kschoche @lukeoleson @mmoghaddam385 @jbonzo
```

Ref: DEVREL-139