### PR TITLE
[DEVREL-143] Sync workflow: create PRs via GitHub App token

### DIFF
--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -21,10 +21,24 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
+      # Mint a short-lived token for the org GitHub App. The default GITHUB_TOKEN
+      # can't open PRs (org policy: "Allow GitHub Actions to create and approve
+      # pull requests" is off). The App token isn't subject to that restriction,
+      # triggers required checks, and authors the PR as the app bot so a human
+      # can still review.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.MASSIVE_CLIENT_LIBRARY_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.MASSIVE_CLIENT_LIBRARY_AUTOMATION_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: true
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -90,13 +104,11 @@ jobs:
         if: steps.diff.outputs.changed == 'true'
         id: pr
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh label create automated --color ededed --description "Automated PR" --force >/dev/null 2>&1 || true
           url=$(gh pr create \
             --base master --head "$BRANCH" \
             --title "[bot] Sync client-jvm with OpenAPI spec ($(date -u +'%Y-%m-%d'))" \
-            --label automated \
             --body "Automated regeneration from \`https://api.massive.com/openapi\` via \`scripts/generate.sh\` (openapi-generator 7.23.0).
 
           - Regenerated REST client: \`com.massive.client\` (apis, models, infrastructure, docs, tests)
@@ -105,6 +117,9 @@ jobs:
 
           Please review the diff before merging.")
           echo "url=$url" >> "$GITHUB_OUTPUT"
+          # Best-effort label — don't fail the run if the app lacks label perms.
+          gh label create automated --color ededed --description "Automated PR" --force >/dev/null 2>&1 || true
+          gh pr edit "$url" --add-label automated >/dev/null 2>&1 || true
 
       - name: Notify Slack
         if: steps.diff.outputs.changed == 'true'


### PR DESCRIPTION
Linear: [DEVREL-143](https://linear.app/massive-com/issue/DEVREL-143/client-jvm-sync-workflow-create-prs-via-github-app-token)

## Problem
The daily OpenAPI sync workflow failed at PR creation:

> GitHub Actions is not permitted to create or approve pull requests (createPullRequest)

The repo's "Allow GitHub Actions to create and approve pull requests" setting is off (org default, not toggleable at the repo level), which blocks the default `GITHUB_TOKEN` from opening PRs.

## Fix
Switch to the org-owned GitHub App:
- New **Generate GitHub App token** step (`actions/create-github-app-token@v2`) using `vars.MASSIVE_CLIENT_LIBRARY_AUTOMATION_APP_ID` + `secrets.MASSIVE_CLIENT_LIBRARY_AUTOMATION_APP_PRIVATE_KEY`.
- **Checkout** and **push** use the app token, so branch pushes trigger required checks.
- **`gh pr create`** uses the app token → PR authored by the app bot (a human reviewer stays valid).